### PR TITLE
CONF: LINTING Update .gitignore and enable Prettier EOL handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -26,9 +26,15 @@ export default tseslint.config(
   },
   {
     rules: {
+      'prettier/prettier': [
+        'error',
+        {
+          endOfLine: 'auto',
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
     },
   },
 );


### PR DESCRIPTION
Updated `.gitignore` to exclude the `.idea` folder. Adjusted ESLint configuration to enable Prettier's end-of-line handling, preventing errors related to incorrect EOL characters.

Fixed: ESLint: Delete `␍` (prettier/prettier) errors