### PR TITLE
REFACTOR: (BE) Changed user status & added status guard [CAP-32]

### DIFF
--- a/backend/prisma/migrations/20250804125746_user_status/migration.sql
+++ b/backend/prisma/migrations/20250804125746_user_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "disabledAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -53,12 +53,6 @@ enum Role {
   admin
 }
 
-enum UserAccountStatus {
-  active
-  disabled
-  deleted
-}
-
 model User {
   id String @id @default(uuid()) @db.Uuid
   /// @DtoApiHidden
@@ -82,8 +76,9 @@ model User {
   /// @DtoCreateHidden
   updatedAt DateTime @default(now())
   /// @DtoReadOnly
+  disabledAt DateTime?
+  /// @DtoReadOnly
   deletedAt DateTime?
-
 }
 
 model UserAccount {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { SupabaseModule } from './lib/supabase/supabase.module';
 import { CoursesModule } from './modules/courses/courses.module';
 import { TestModule } from './modules/test/test.module';
 import { UsersModule } from './modules/users/users.module';
+import { UserStatusGuard } from './common/guards/user-status.guard';
 
 @Module({
   imports: [
@@ -33,6 +34,10 @@ import { UsersModule } from './modules/users/users.module';
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: UserStatusGuard,
     },
     {
       provide: APP_GUARD,

--- a/backend/src/common/decorators/user-status.decorator.ts
+++ b/backend/src/common/decorators/user-status.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_STATUS_BYPASS = 'isStatusBypass';
+export const StatusBypass = () => SetMetadata(IS_STATUS_BYPASS, true);

--- a/backend/src/common/guards/auth.guard.ts
+++ b/backend/src/common/guards/auth.guard.ts
@@ -8,6 +8,7 @@ import {
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { IS_PUBLIC_KEY } from '../decorators/auth.decorator';
+import { AuthUser } from '../interfaces/auth.user-metadata';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -24,7 +25,7 @@ export class AuthGuard implements CanActivate {
 
     if (isPublic) return true;
 
-    const request: Request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<Request>();
     const token = this.extractTokenFromHeader(request);
 
     if (!token) throw new UnauthorizedException('Access token is missing');
@@ -33,7 +34,7 @@ export class AuthGuard implements CanActivate {
 
     if (payload.error) throw new UnauthorizedException('Invalid access token');
 
-    request['user'] = payload.data.user;
+    request.user = payload.data.user as AuthUser;
 
     return true;
   }

--- a/backend/src/common/guards/role.guard.ts
+++ b/backend/src/common/guards/role.guard.ts
@@ -3,11 +3,12 @@ import {
   ExecutionContext,
   ForbiddenException,
   Injectable,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../enums/roles.enum';
 import { ROLES_KEY } from '../decorators/roles.decorator';
-import { User } from '@supabase/supabase-js';
+import { Request } from 'express';
 
 @Injectable()
 export class RoleGuard implements CanActivate {
@@ -21,9 +22,15 @@ export class RoleGuard implements CanActivate {
 
     if (!requiredRoles) return true;
 
-    const { user }: { user: User } = context.switchToHttp().getRequest();
+    const { user } = context.switchToHttp().getRequest<Request>();
 
-    const userRoles = user.user_metadata.role as Role[];
+    if (!user) throw new UnauthorizedException('User data not found');
+
+    const userRoles = user.user_metadata.role;
+
+    if (!userRoles)
+      throw new UnauthorizedException('Role of the user is not found');
+
     const hasRole = requiredRoles.some((role) => userRoles.includes(role));
 
     if (!hasRole)

--- a/backend/src/common/guards/user-status.guard.ts
+++ b/backend/src/common/guards/user-status.guard.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserAccountStatus } from '../interfaces/auth.user-metadata';
+import { IS_STATUS_BYPASS } from '../decorators/user-status.decorator';
+import { Request } from 'express';
+
+@Injectable()
+export class UserStatusGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const statusBypass = this.reflector.getAllAndOverride<UserAccountStatus>(
+      IS_STATUS_BYPASS,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (statusBypass) return true;
+
+    const { user } = context.switchToHttp().getRequest<Request>();
+
+    if (!user) throw new UnauthorizedException('User data not found');
+
+    const userStatus = user.user_metadata.status;
+
+    if (userStatus === 'disabled')
+      throw new ForbiddenException(
+        "You're account is disabled, please contact your administrator for inqiuries",
+      );
+
+    if (userStatus === 'deleted')
+      throw new ForbiddenException(
+        "You're account is deleted, please contact your administrator for inqiuries",
+      );
+
+    return true;
+  }
+}

--- a/backend/src/common/interfaces/auth.user-metadata.ts
+++ b/backend/src/common/interfaces/auth.user-metadata.ts
@@ -1,7 +1,17 @@
 import { Role } from '@prisma/client';
-import { UserMetadata as SupabaseUserMetadata } from '@supabase/supabase-js';
+import {
+  UserMetadata as SupabaseUserMetadata,
+  User,
+} from '@supabase/supabase-js';
+
+export interface AuthUser extends User {
+  user_metadata: UserMetadata;
+}
 
 export interface UserMetadata extends SupabaseUserMetadata {
-  role: Role;
-  user_id: string;
+  role?: Role;
+  status?: UserAccountStatus;
+  user_id?: string;
 }
+
+export type UserAccountStatus = 'active' | 'disabled' | 'deleted';

--- a/backend/src/common/types/request.d.ts
+++ b/backend/src/common/types/request.d.ts
@@ -1,7 +1,8 @@
 import { User } from '@supabase/supabase-js';
+import { AuthUser } from '../interfaces/auth.user-metadata';
 
 declare module 'express' {
   interface Request {
-    user: User;
+    user?: AuthUser;
   }
 }

--- a/backend/src/generated/nestjs-dto/user.dto.ts
+++ b/backend/src/generated/nestjs-dto/user.dto.ts
@@ -39,5 +39,11 @@ export class UserDto {
     format: 'date-time',
     nullable: true,
   })
+  disabledAt: Date | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
   deletedAt: Date | null;
 }

--- a/backend/src/generated/nestjs-dto/user.entity.ts
+++ b/backend/src/generated/nestjs-dto/user.entity.ts
@@ -69,5 +69,11 @@ export class User {
     format: 'date-time',
     nullable: true,
   })
+  disabledAt: Date | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
   deletedAt: Date | null;
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -21,6 +21,7 @@ export class AuthService {
       email_confirm: true,
       user_metadata: {
         role: role,
+        status: 'active',
       },
     });
 

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -26,7 +26,6 @@ export class UsersService {
     @Inject('PrismaService')
     private prisma: CustomPrismaService<ExtendedPrismaClient>,
     private authService: AuthService,
-
   ) {}
 
   async create(createUserDto: CreateUserWithAccountDto) {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -21,5 +21,6 @@
     "paths": {
       "@/*": ["*"]
     }
-  }
+  },
+  "include": ["src", "src/common/types/request.d.ts"]
 }


### PR DESCRIPTION
Prisma Schema
- Removed UserAccountStatus enum
- Added disabledAt column in the User model
- Generated new migration, dto, and client files

Types
- Added AuthUser that extends supabase's User and adds type for user_metadata
- Added status to UserMetadata and made the properties optional
- Changed express Request's user to AuthUser
- Added request.d.ts to tsconfig.json include property

Guards
- Implemented User Status guard to filter out disabled and deleted status from user request
- Added StatusBypass decorator to bypass this guard filter
- Refactored te AuthGuard and RoleGuard to use the new Request type
- Implemented additional error handling for the RoleGuard