### PR TITLE
FEAT: (BE) Create & Update User Refactor [CAP-33]

### DIFF
--- a/backend/prisma/migrations/20250805204431_updated_at_default_value/migration.sql
+++ b/backend/prisma/migrations/20250805204431_updated_at_default_value/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "StaffDetails" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "StudentDetails" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "UserAccount" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "UserDetails" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -75,11 +75,12 @@ model User {
   firstName String
   middleName String?
   lastName String
+  /// @DtoReadOnly
   role Role
 
   /// @DtoReadOnly
   createdAt DateTime @default(now())
-  /// @DtoCreateHidden
+  /// @DtoReadOnly
   updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   disabledAt DateTime?
@@ -101,7 +102,7 @@ model UserAccount {
 
   /// @DtoReadOnly
   createdAt DateTime @default(now())
-  /// @DtoCreateHidden
+  /// @DtoReadOnly
   updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
@@ -121,7 +122,7 @@ model UserDetails {
 
   /// @DtoReadOnly
   createdAt DateTime @default(now())
-  /// @DtoCreateHidden
+  /// @DtoReadOnly
   updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
@@ -152,7 +153,7 @@ model StudentDetails {
 
   /// @DtoReadOnly
   createdAt DateTime @default(now())
-  /// @DtoCreateHidden
+  /// @DtoReadOnly
   updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
@@ -173,7 +174,7 @@ model StaffDetails {
 
   /// @DtoReadOnly
   createdAt DateTime @default(now())
-  /// @DtoCreateHidden
+  /// @DtoReadOnly
   updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -80,7 +80,7 @@ model User {
   /// @DtoReadOnly
   createdAt DateTime @default(now())
   /// @DtoCreateHidden
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   disabledAt DateTime?
   /// @DtoReadOnly
@@ -102,7 +102,7 @@ model UserAccount {
   /// @DtoReadOnly
   createdAt DateTime @default(now())
   /// @DtoCreateHidden
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
 }
@@ -122,7 +122,7 @@ model UserDetails {
   /// @DtoReadOnly
   createdAt DateTime @default(now())
   /// @DtoCreateHidden
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
 }
@@ -153,7 +153,7 @@ model StudentDetails {
   /// @DtoReadOnly
   createdAt DateTime @default(now())
   /// @DtoCreateHidden
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
 }
@@ -174,7 +174,7 @@ model StaffDetails {
   /// @DtoReadOnly
   createdAt DateTime @default(now())
   /// @DtoCreateHidden
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   /// @DtoReadOnly
   deletedAt DateTime?
 }

--- a/backend/src/generated/nestjs-dto/create-user.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-user.dto.ts
@@ -1,6 +1,5 @@
-import { Role } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateUserDto {
   @ApiProperty({
@@ -23,11 +22,4 @@ export class CreateUserDto {
   @IsNotEmpty()
   @IsString()
   lastName: string;
-  @ApiProperty({
-    enum: Role,
-    enumName: 'Role',
-  })
-  @IsNotEmpty()
-  @IsEnum(Role)
-  role: Role;
 }

--- a/backend/src/generated/nestjs-dto/update-user.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-user.dto.ts
@@ -1,6 +1,5 @@
-import { Role } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserDto {
   @ApiProperty({
@@ -25,12 +24,4 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   lastName?: string;
-  @ApiProperty({
-    enum: Role,
-    enumName: 'Role',
-    required: false,
-  })
-  @IsOptional()
-  @IsEnum(Role)
-  role?: Role;
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -17,6 +17,16 @@ export class AuthService {
     this.siteUrl = this.configService.get('SITE_URL')!;
   }
 
+  /**
+   * Creates a new Supabase user account with the given email, password, and role.
+   * The account will be marked as active and the email will be auto-confirmed.
+   *
+   * @param email - The email address for the new user.
+   * @param password - The password for the new user.
+   * @param role - The role to assign to the user (e.g., 'student', 'admin').
+   * @returns The created Supabase user object.
+   * @throws BadRequestException if the Supabase account creation fails.
+   */
   async create(email: string, password: string, role: Role) {
     const account = await this.supabase.auth.admin.createUser({
       email: email,
@@ -54,6 +64,14 @@ export class AuthService {
     return account.data.user;
   }
 
+  /**
+   * Updates the metadata of an existing Supabase user account.
+   *
+   * @param id - The Supabase UID of the user to update.
+   * @param metadata - Partial user metadata to be merged into the existing data.
+   * @returns The updated Supabase user object.
+   * @throws BadRequestException if the update operation fails.
+   */
   async updateMetadata(id: string, metadata: Partial<UserMetadata>) {
     const account = await this.supabase.auth.admin.updateUserById(id, {
       user_metadata: metadata,
@@ -65,5 +83,22 @@ export class AuthService {
     }
 
     return account.data.user;
+  }
+
+  /**
+   * Deletes a Supabase user account by UID.
+   *
+   * @param uid - The UID of the user to delete.
+   * @throws BadRequestException if the deletion fails.
+   */
+  async delete(uid: string) {
+    const account = await this.supabase.auth.admin.deleteUser(uid);
+
+    if (account.error) {
+      this.logger.error(`Failed to create account: ${account.error.message}`);
+      throw new BadRequestException('Error deleting Supabase account');
+    }
+
+    this.logger.log(`Successful account deletion`);
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
    * @returns The created Supabase user object.
    * @throws BadRequestException if the Supabase account creation fails.
    */
-  async create(email: string, password: string, role: Role) {
+  async create(role: Role, email: string, password?: string) {
     const account = await this.supabase.auth.admin.createUser({
       email: email,
       password: password,

--- a/backend/src/modules/users/dto/create-user.dto.ts
+++ b/backend/src/modules/users/dto/create-user.dto.ts
@@ -10,22 +10,17 @@ import { CreateUserDto } from '@/generated/nestjs-dto/create-user.dto';
 import { CreateUserDetailsDto } from '@/generated/nestjs-dto/create-userDetails.dto';
 import { CreateStudentDetailsDto } from '@/generated/nestjs-dto/create-studentDetails.dto';
 import { CreateStaffDetailsDto } from '@/generated/nestjs-dto/create-staffDetails.dto';
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
-
-export class CreateUserDtoNoRole extends OmitType(CreateUserDto, [
-  'role',
-] as const) {}
 
 export class CreateUserBaseDto {
   @ValidateNested()
-  @Type(() => CreateUserDtoNoRole)
-  user: CreateUserDtoNoRole;
+  @Type(() => CreateUserDto)
+  user: CreateUserDto;
 
-  @IsOptional()
   @ValidateNested()
   @Type(() => UserCredentialsDto)
-  credentials?: UserCredentialsDto;
+  credentials: UserCredentialsDto;
 
   @IsOptional()
   @ValidateNested()
@@ -56,7 +51,7 @@ export class CreateUserStaffDto extends CreateUserBaseDto {
   })
   @IsNotEmpty()
   @IsEnum(['mentor', 'admin'])
-  role: Omit<Role, 'student'>;
+  role: Exclude<Role, 'student'>;
 
   @ValidateNested()
   @Type(() => CreateStaffDetailsDto)

--- a/backend/src/modules/users/dto/create-user.dto.ts
+++ b/backend/src/modules/users/dto/create-user.dto.ts
@@ -1,11 +1,64 @@
 import { Type } from 'class-transformer';
-import { IsOptional, ValidateNested } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
 import { UserCredentialsDto } from './user-credentials.dto';
 import { CreateUserDto } from '@/generated/nestjs-dto/create-user.dto';
+import { CreateUserDetailsDto } from '@/generated/nestjs-dto/create-userDetails.dto';
+import { CreateStudentDetailsDto } from '@/generated/nestjs-dto/create-studentDetails.dto';
+import { CreateStaffDetailsDto } from '@/generated/nestjs-dto/create-staffDetails.dto';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { Role } from '@prisma/client';
 
-export class CreateUserWithAccountDto extends CreateUserDto {
+export class CreateUserDtoNoRole extends OmitType(CreateUserDto, [
+  'role',
+] as const) {}
+
+export class CreateUserBaseDto {
+  @ValidateNested()
+  @Type(() => CreateUserDtoNoRole)
+  user: CreateUserDtoNoRole;
+
   @IsOptional()
   @ValidateNested()
   @Type(() => UserCredentialsDto)
   credentials?: UserCredentialsDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateUserDetailsDto)
+  userDetails?: CreateUserDetailsDto;
+}
+
+export class CreateUserFullDto extends CreateUserBaseDto {
+  @ApiProperty({
+    enum: Role,
+    enumName: 'Role',
+  })
+  @IsNotEmpty()
+  @IsEnum(Role)
+  role: Role;
+}
+
+export class CreateUserStudentDto extends CreateUserBaseDto {
+  @ValidateNested()
+  @Type(() => CreateStudentDetailsDto)
+  specificDetails: CreateStudentDetailsDto;
+}
+
+export class CreateUserStaffDto extends CreateUserBaseDto {
+  @ApiProperty({
+    enum: ['mentor', 'admin'],
+    enumName: 'StaffRole',
+  })
+  @IsNotEmpty()
+  @IsEnum(['mentor', 'admin'])
+  role: Omit<Role, 'student'>;
+
+  @ValidateNested()
+  @Type(() => CreateStaffDetailsDto)
+  specificDetails: CreateStaffDetailsDto;
 }

--- a/backend/src/modules/users/dto/invite-user.dto.ts
+++ b/backend/src/modules/users/dto/invite-user.dto.ts
@@ -1,7 +1,17 @@
-import { IsEmail } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty } from 'class-validator';
 import { CreateUserDto } from '@/generated/nestjs-dto/create-user.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '@prisma/client';
 
 export class InviteUserDto extends CreateUserDto {
+  @ApiProperty({
+    enum: Role,
+    enumName: 'Role',
+  })
+  @IsNotEmpty()
+  @IsEnum(Role)
+  role: Exclude<Role, 'student'>;
+
   @IsEmail({}, { message: 'The value is not a valid email format' })
   email: string;
 }

--- a/backend/src/modules/users/dto/update-user-details.dto.ts
+++ b/backend/src/modules/users/dto/update-user-details.dto.ts
@@ -1,20 +1,15 @@
-import { OmitType } from '@nestjs/swagger';
 import { UpdateUserDto } from '@/generated/nestjs-dto/update-user.dto';
-import { IsEnum, IsOptional, ValidateNested } from 'class-validator';
+import { IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { UpdateUserDetailsDto } from '@/generated/nestjs-dto/update-userDetails.dto';
 import { UpdateStudentDetailsDto } from '@/generated/nestjs-dto/update-studentDetails.dto';
 import { UpdateStaffDetailsDto } from '@/generated/nestjs-dto/update-staffDetails.dto';
 
-export class UpdateUserNoRoleDto extends OmitType(UpdateUserDto, [
-  'role',
-] as const) {}
-
 export class UpdateUserBaseDto {
   @IsOptional()
   @ValidateNested()
-  @Type(() => UpdateUserNoRoleDto)
-  user?: UpdateUserNoRoleDto;
+  @Type(() => UpdateUserDto)
+  user?: UpdateUserDto;
 
   @IsOptional()
   @ValidateNested()

--- a/backend/src/modules/users/dto/update-user-details.dto.ts
+++ b/backend/src/modules/users/dto/update-user-details.dto.ts
@@ -1,4 +1,36 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from '@/generated/nestjs-dto/create-user.dto';
+import { OmitType } from '@nestjs/swagger';
+import { UpdateUserDto } from '@/generated/nestjs-dto/update-user.dto';
+import { IsEnum, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { UpdateUserDetailsDto } from '@/generated/nestjs-dto/update-userDetails.dto';
+import { UpdateStudentDetailsDto } from '@/generated/nestjs-dto/update-studentDetails.dto';
+import { UpdateStaffDetailsDto } from '@/generated/nestjs-dto/update-staffDetails.dto';
 
-export class UpdateUserDetailsDto extends PartialType(CreateUserDto) {}
+export class UpdateUserNoRoleDto extends OmitType(UpdateUserDto, [
+  'role',
+] as const) {}
+
+export class UpdateUserBaseDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateUserNoRoleDto)
+  user?: UpdateUserNoRoleDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateUserDetailsDto)
+  userDetails?: UpdateUserDetailsDto;
+}
+
+export class UpdateUserStudentDto extends UpdateUserBaseDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateStudentDetailsDto)
+  specificDetails?: UpdateStudentDetailsDto;
+}
+export class UpdateUserStaffDto extends UpdateUserBaseDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateStaffDetailsDto)
+  specificDetails?: UpdateStaffDetailsDto;
+}

--- a/backend/src/modules/users/dto/user-credentials.dto.ts
+++ b/backend/src/modules/users/dto/user-credentials.dto.ts
@@ -1,9 +1,10 @@
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class UserCredentialsDto {
   @IsEmail({}, { message: 'The value is not a valid email format' })
   email: string;
 
+  @IsOptional()
   @IsNotEmpty({ message: 'The password is empty' })
-  password: string;
+  password?: string;
 }

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -63,8 +63,6 @@ export class UsersController {
    */
   @Post()
   @Roles(Role.ADMIN)
-  // @Public()
-  // @StatusBypass()
   @ApiCreatedResponse({ type: User })
   @ApiException(() => BadRequestException)
   @ApiException(() => InternalServerErrorException)
@@ -121,7 +119,10 @@ export class UsersController {
   @ApiException(() => InternalServerErrorException)
   async createStaff(@Body() createUserDto: CreateUserStaffDto): Promise<User> {
     try {
-      const user = await this.usersService.create('student', createUserDto);
+      const user = await this.usersService.create(
+        createUserDto.role,
+        createUserDto,
+      );
 
       return user;
     } catch (err) {
@@ -198,9 +199,7 @@ export class UsersController {
    * The user should be have a student role.
    */
   @Put(':id/student')
-  // @Roles(Role.ADMIN)
-  @Public()
-  @StatusBypass()
+  @Roles(Role.ADMIN)
   @ApiCreatedResponse({ type: User })
   @ApiException(() => BadRequestException)
   @ApiException(() => InternalServerErrorException)

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -1,5 +1,6 @@
 import { Roles } from '@/common/decorators/roles.decorator';
 import { Role } from '@/common/enums/roles.enum';
+import { Role as RoleType } from '@prisma/client';
 import { User } from '@/generated/nestjs-dto/user.entity';
 import { InviteUserDto } from '@/modules/users/dto/invite-user.dto';
 import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
@@ -20,16 +21,29 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiOkResponse,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { Request } from 'express';
-import { CreateUserWithAccountDto } from './dto/create-user.dto';
+import {
+  CreateUserFullDto,
+  CreateUserStaffDto,
+  CreateUserStudentDto,
+} from './dto/create-user.dto';
 import { FilterUserDto } from './dto/filter-user.dto';
 import { PaginatedUsersDto } from './dto/paginated-user.dto';
-import { UpdateUserDetailsDto } from './dto/update-user-details.dto';
+import {
+  UpdateUserBaseDto,
+  UpdateUserStaffDto,
+  UpdateUserStudentDto,
+} from './dto/update-user-details.dto';
 import { UserWithRelations } from './dto/user-with-relations.dto';
 import { UsersService } from './users.service';
+import { Public } from '@/common/decorators/auth.decorator';
+import { StatusBypass } from '@/common/decorators/user-status.decorator';
 
 /**
  *
@@ -49,14 +63,67 @@ export class UsersController {
    */
   @Post()
   @Roles(Role.ADMIN)
+  // @Public()
+  // @StatusBypass()
   @ApiCreatedResponse({ type: User })
   @ApiException(() => BadRequestException)
   @ApiException(() => InternalServerErrorException)
-  async create(@Body() createUserDto: CreateUserWithAccountDto): Promise<User> {
+  async create(@Body() createUserDto: CreateUserFullDto): Promise<User> {
     try {
-      const user = await this.usersService.create(createUserDto);
+      const user = await this.usersService.create(
+        createUserDto.role,
+        createUserDto,
+      );
 
-      return user.user;
+      return user;
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('Failed to create user');
+    }
+  }
+
+  /**
+   * Create a new student user
+   *
+   * @remarks
+   * This operation creates both a user and a supabase auth account.
+   * It also has additional properties for student specific details.
+   *
+   */
+  @Post('/student')
+  @Roles(Role.ADMIN)
+  @ApiException(() => BadRequestException)
+  @ApiException(() => InternalServerErrorException)
+  async createStudent(
+    @Body() createUserDto: CreateUserStudentDto,
+  ): Promise<User> {
+    try {
+      const user = await this.usersService.create('student', createUserDto);
+
+      return user;
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('Failed to create user');
+    }
+  }
+
+  /**
+   * Create a new staff user
+   *
+   * @remarks
+   * This operation creates both a user and a supabase auth account.
+   * It also has additional properties for staff specific details.
+   *
+   */
+  @Post('/staff')
+  @Roles(Role.ADMIN)
+  @ApiException(() => BadRequestException)
+  @ApiException(() => InternalServerErrorException)
+  async createStaff(@Body() createUserDto: CreateUserStaffDto): Promise<User> {
+    try {
+      const user = await this.usersService.create('student', createUserDto);
+
+      return user;
     } catch (err) {
       if (err instanceof BadRequestException) throw err;
       throw new InternalServerErrorException('Failed to create user');
@@ -92,21 +159,31 @@ export class UsersController {
    *
    */
   @Put('/me')
+  @ApiExtraModels(UpdateUserStudentDto, UpdateUserStaffDto)
   @ApiCreatedResponse({ type: User })
   @ApiException(() => BadRequestException)
   @ApiException(() => InternalServerErrorException)
   async updateOwnUserDetails(
     @Req() request: Request,
-    @Body() updateUserDto: UpdateUserDetailsDto,
+    @Body() updateUserDto: UpdateUserBaseDto,
   ): Promise<User> {
-    if (!request.user) {
-      throw new BadRequestException('User not found');
-    }
+    if (!request.user) throw new BadRequestException('User not found');
 
-    const userId = request.user.user_metadata?.user_id as string;
+    if (
+      !request.user.user_metadata ||
+      !request.user.user_metadata.user_id ||
+      !request.user.user_metadata.role
+    )
+      throw new BadRequestException('User metadata not found');
+
+    const { user_id, role } = request.user.user_metadata;
 
     try {
-      return await this.usersService.updateUserDetails(userId, updateUserDto);
+      return await this.usersService.updateUserDetails(
+        user_id,
+        role,
+        updateUserDto,
+      );
     } catch (err) {
       if (err instanceof BadRequestException) throw err;
       throw new InternalServerErrorException(`Failed to update user: ${err}`);
@@ -114,23 +191,31 @@ export class UsersController {
   }
 
   /**
-   * Update user details (Admin only)
+   * Update student user details (Admin only)
    *
-   *
-   * @remarks This operation updates the user details in the database
-   *
+   * @remarks
+   * This operation updates the user details in the database.
+   * The user should be have a student role.
    */
-  @Put(':id')
-  @Roles(Role.ADMIN)
+  @Put(':id/student')
+  // @Roles(Role.ADMIN)
+  @Public()
+  @StatusBypass()
   @ApiCreatedResponse({ type: User })
   @ApiException(() => BadRequestException)
   @ApiException(() => InternalServerErrorException)
-  async updateUserDetails(
+  async updateUserStudentDetails(
     @Param('id') id: string,
-    @Body() updateUserDto: UpdateUserDetailsDto,
+    @Body() updateUserDto: UpdateUserStudentDto,
   ): Promise<User> {
     try {
-      return await this.usersService.updateUserDetails(id, updateUserDto);
+      const user = await this.usersService.findOne(id);
+
+      return await this.usersService.updateUserDetails(
+        id,
+        user.role,
+        updateUserDto,
+      );
     } catch (err) {
       if (err instanceof BadRequestException) throw err;
       throw new InternalServerErrorException('Failed to update user');
@@ -138,16 +223,43 @@ export class UsersController {
   }
 
   /**
-   * Retrieves a paginated list of users based on the provided filter parameters.
+   * Update staff user details (Admin only)
    *
+   * @remarks
+   * This operation updates the user details in the database.
+   * The user should be have a mentor or admin role.
+   */
+  @Put(':id/staff')
+  @Roles(Role.ADMIN)
+  @ApiCreatedResponse({ type: User })
+  @ApiException(() => BadRequestException)
+  @ApiException(() => InternalServerErrorException)
+  async updateUserStaffDetails(
+    @Param('id') id: string,
+    @Body() updateUserDto: UpdateUserStaffDto,
+  ): Promise<User> {
+    try {
+      const user = await this.usersService.findOne(id);
+
+      return await this.usersService.updateUserDetails(
+        id,
+        user.role,
+        updateUserDto,
+      );
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new InternalServerErrorException('Failed to update user');
+    }
+  }
+
+  /**
+   * Get users
+   *
+   * @remarks
+   * Retrieves a paginated list of users based on the provided filter parameters.
    * - **Access:** Requires `ADMIN` role.
    * - **Filtering & Pagination:** Uses the `FilterUserDto` to define query parameters such as search terms, sorting, and page size.
    *
-   * @param {FilterUserDto} filters - Query parameters for filtering, sorting, and pagination.
-   * @returns {Promise<PaginatedUsersDto>} A paginated list of users matching the provided filters.
-   *
-   * @throws {BadRequestException} If the provided filters are invalid or cannot be processed.
-   * @throws {InternalServerErrorException} If an unexpected server error occurs while fetching users.
    */
 
   @Get()
@@ -169,17 +281,14 @@ export class UsersController {
   }
 
   /**
-   * Retrieves a specific user by their unique identifier.
+   * Get user by id
+
    *
+   * @remarks
+   * Retrieves a specific user by their unique identifier.
    * - **Validation:** Ensures the provided `id` is a valid identifier format.
    * - **Not Found Handling:** Throws an error if no matching user is found.
    *
-   * @param {User['id']} id - The unique identifier of the user to retrieve.
-   * @returns {Promise<User>} The user matching the provided ID.
-   *
-   * @throws {BadRequestException} If the provided ID format is invalid.
-   * @throws {NotFoundException} If no user exists with the given ID.
-   * @throws {InternalServerErrorException} If an unexpected server error occurs while fetching the user.
    */
   @Get(':id')
   @ApiOkResponse({ description: 'User found successfully', type: User })

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -9,15 +9,24 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import {
+  CreateUserFullDto,
+  CreateUserStaffDto,
+  CreateUserStudentDto,
+} from './dto/create-user.dto';
+import {
+  UpdateUserStudentDto,
+  UpdateUserStaffDto,
+} from './dto/update-user-details.dto';
+import { Prisma, Role } from '@prisma/client';
 import { isUUID } from 'class-validator';
 import { CustomPrismaService } from 'nestjs-prisma';
-import { CreateUserWithAccountDto } from './dto/create-user.dto';
 import { FilterUserDto } from './dto/filter-user.dto';
 import { PaginatedUsersDto } from './dto/paginated-user.dto';
-import { UpdateUserDetailsDto } from './dto/update-user-details.dto';
 import { UserWithRelations } from './dto/user-with-relations.dto';
 import { InviteUserDto } from '@/modules/users/dto/invite-user.dto';
+import { User } from '@supabase/supabase-js';
+import { UserDto } from '@/generated/nestjs-dto/user.dto';
 
 @Injectable()
 export class UsersService {
@@ -29,41 +38,113 @@ export class UsersService {
     private authService: AuthService,
   ) {}
 
-  async create(createUserDto: CreateUserWithAccountDto) {
+  /**
+   * Handles Supabase account creation and executes a callback that creates the corresponding Prisma user.
+   * It also sets the user's metadata which will be used in handling of role and status guards.
+   * If Prisma creation fails, it will delete the Supabase account.
+   *
+   * @param credentials - The user's login credentials.
+   * @param role - Role of the user (student, admin, etc).
+   * @param callback - A function to create the Prisma user, passed the Supabase user object.
+   * @returns The created Prisma user.
+   * @throws BadRequestException if user creation in DB fails.
+   */
+  async accountCreationHandler(
+    credentials: CreateUserFullDto['credentials'],
+    role: Role,
+    callback: (user: User) => Promise<UserDto>,
+  ) {
+    const account = await this.authService.create(
+      credentials?.email || 'test@email',
+      credentials?.password || '1234',
+      role,
+    );
     try {
-      const account = await this.authService.create(
-        createUserDto.credentials?.email || 'test@email',
-        createUserDto.credentials?.password || '1234',
-        createUserDto.role,
-      );
+      const user = await callback(account);
+      await this.authService.updateMetadata(account.id, {
+        user_id: user.id,
+      });
 
-      return await this.prisma.client.$transaction(async (tx) => {
-        const user = await tx.user.create({
-          data: {
-            firstName: createUserDto.firstName,
-            middleName: createUserDto.middleName,
-            lastName: createUserDto.lastName,
-            role: createUserDto.role,
+      return user;
+    } catch (err) {
+      this.logger.error(`Error creating user in DB: ${err}`);
+      if (
+        err instanceof Prisma.PrismaClientValidationError ||
+        err instanceof Prisma.PrismaClientKnownRequestError
+      ) {
+        await this.authService.delete(account.id);
+      }
+      throw new BadRequestException('Error creating user in DB');
+    }
+  }
+
+  /**
+   * Creates a new user with associated Supabase account and database records.
+   *
+   * @param role - The role of the user being created.
+   * @param createUserDto - The complete user creation payload.
+   * @returns The created user object.
+   * @throws InternalServerErrorException if user creation fails.
+   */
+  async create(
+    role: Role,
+    createUserDto:
+      | CreateUserFullDto
+      | CreateUserStudentDto
+      | CreateUserStaffDto,
+  ) {
+    try {
+      const {
+        user: userDto,
+        credentials,
+        userDetails: userDetailsDto,
+      } = createUserDto;
+
+      const user = await this.accountCreationHandler(
+        credentials,
+        role,
+        async (account) => {
+          const baseUserData: Prisma.UserCreateInput = {
+            ...userDto,
+            role,
             userAccount: {
               create: {
                 authUid: account.id,
                 email: account.email,
               },
             },
-          },
-        });
+            userDetails: {
+              create: userDetailsDto || {
+                dateJoined: new Date(),
+              },
+            },
+          };
 
-        await this.authService.updateMetadata(account.id, {
-          user_id: user.id,
-        });
+          if (
+            !('role' in createUserDto) &&
+            'specificDetails' in createUserDto
+          ) {
+            baseUserData.studentDetails = {
+              create: createUserDto.specificDetails,
+            };
+          } else if (
+            (role === 'mentor' || role === 'admin') &&
+            'specificDetails' in createUserDto
+          ) {
+            baseUserData.staffDetails = {
+              create: createUserDto.specificDetails,
+            };
+          }
 
-        return { user };
-      });
+          return await this.prisma.client.user.create({
+            data: baseUserData,
+          });
+        },
+      );
+
+      return user;
     } catch (err) {
       this.logger.error(`Failed to create user: ${err}`);
-
-      //TODO: implement deleting the account that was just created upon error
-      // await this.authService.delete(account.id);
 
       throw new InternalServerErrorException('Failed to create the user');
     }
@@ -104,17 +185,50 @@ export class UsersService {
     });
   }
 
-  async updateUserDetails(userId: string, updateUserDto: UpdateUserDetailsDto) {
-    //TODO: Include other fields later on if there are updates in the schema
-    //TODO: Other user details are not included, would be updated if implemented in the create method
+  /**
+   * Updates a user’s basic personal details (first name, middle name, last name).
+   *
+   * @param userId - The UUID of the user.
+   * @param role - The Role of the user ("student", "mentor", "admin").
+   * @param updateUserDto - Partial fields to update.
+   * @returns The updated user object.
+   * @throws InternalServerErrorException if update fails.
+   */
+  async updateUserDetails(
+    userId: string,
+    role: Role,
+    updateUserDto: UpdateUserStudentDto | UpdateUserStaffDto,
+  ) {
     try {
+      const {
+        user: userDto,
+        userDetails: userDetailsDto,
+        specificDetails: specificDetailsDto,
+      } = updateUserDto;
+
+      const baseUserData: Prisma.UserUpdateInput = {
+        ...userDto,
+        userDetails: {
+          update: userDetailsDto,
+        },
+      };
+
+      if (!('role' in updateUserDto) && 'specificDetails' in updateUserDto) {
+        baseUserData.studentDetails = {
+          update: specificDetailsDto,
+        };
+      } else if (
+        (role === 'mentor' || role === 'admin') &&
+        'specificDetails' in updateUserDto
+      ) {
+        baseUserData.staffDetails = {
+          update: specificDetailsDto,
+        };
+      }
+
       return await this.prisma.client.user.update({
         where: { id: userId },
-        data: {
-          firstName: updateUserDto.firstName,
-          middleName: updateUserDto.middleName,
-          lastName: updateUserDto.lastName,
-        },
+        data: baseUserData,
       });
     } catch (err) {
       this.logger.error(`Failed to update user db entry: ${err}`);
@@ -122,6 +236,13 @@ export class UsersService {
     }
   }
 
+  /**
+   * Finds all users that match provided filters (e.g. role, search keyword) with pagination.
+   *
+   * @param filters - Filter and pagination options.
+   * @returns Paginated list of users with metadata.
+   * @throws BadRequestException or InternalServerErrorException based on the failure type.
+   */
   async findAll(filters: FilterUserDto): Promise<PaginatedUsersDto> {
     try {
       const where: Prisma.UserWhereInput = {};
@@ -152,8 +273,6 @@ export class UsersService {
         }));
       }
 
-      where.disabledAt = null;
-
       const [users, meta] = await this.prisma.client.user
         .paginate({
           where,
@@ -180,6 +299,15 @@ export class UsersService {
     }
   }
 
+  /**
+   * Finds a user by their ID, including related records like userAccount and userDetails.
+   *
+   * @param id - UUID of the user.
+   * @returns The user and their related entities.
+   * @throws BadRequestException if the ID format is invalid.
+   * @throws NotFoundException if the user does not exist.
+   * @throws InternalServerErrorException for all other errors.
+   */
   async findOne(id: string): Promise<UserWithRelations> {
     try {
       if (!isUUID(id)) {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -55,12 +55,13 @@ export class UsersService {
     callback: (user: User) => Promise<UserDto>,
   ) {
     const account = await this.authService.create(
-      credentials?.email || 'test@email',
-      credentials?.password || '1234',
       role,
+      credentials.email,
+      credentials.password,
     );
     try {
       const user = await callback(account);
+
       await this.authService.updateMetadata(account.id, {
         user_id: user.id,
       });


### PR DESCRIPTION
## Main PR - Aug 5
Prisma Schema
- changed the updateAt to use `@updatedAt` which would provide a default value on creation and also updates the timestamp when the row's data change
- Migration file

Auth Service
- Added JSdoc for the service methods
- Create a delete() function for deleting a supabase auth account

User Service
- Added JSdoc for the service methods
- Added accountCreationHandler() function to handle the account creation by implementing a callback that runs between the account create and update metadata. Also added fail-safe feature to delete the account if the callback fails
- Refactored the create() function to handle additional details
- Refactored the update() function to handle additional details
- Removed disabledAt filtering in findAll() function

Dto
- Refactored the create-user dto
- Refactored the update-user-details dto

User Controller
- Added JSDoc Swagger descriptions for te controller methods
- Fixed some JSDoc formatting which renders a lot of text in the Scalar web docs
- Refactored the create() and update() method to use the refactored services
- Added endpoints for Create /users/student and Create /users/staff
- Added endpoints for Update /users/student and Udate /users/staff

## Fixed Issues - Aug 6
Prisma Schema
- Changed updatedAt to be read only as the `@updatedAt` prisma method handles the logic
- Made the role read-only
- Generated new Dto's

Auth Service
- Changed the password to be optional

Create & Update Dto
- Removed the DtoNoRole class
- Made the credentials not optional
- Added role property for Invite User Dto

User Service
- Removed the default email and password

User Controller
- Removed the `@Public()` and `@StatusBypass` in updateUserStudentDetails()
- Fixed createStaff() to handle the role in Dto instead of 'student' value