### PR TITLE
FEAT: (BE)  implement authenticated user details retrieval via Supabase auth UID [CAP-25]

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,7 +95,7 @@ model UserAccount {
   /// @DtoApiHidden
   user User @relation(fields: [userId], references: [id])
 
-  authUid String
+  authUid String  @unique
   /// @IsEmail
   email String?
 

--- a/backend/src/common/decorators/auth-user.decorator.ts
+++ b/backend/src/common/decorators/auth-user.decorator.ts
@@ -1,0 +1,9 @@
+import { ExecutionContext } from '@nestjs/common';
+import { createParamDecorator } from '@nestjs/common/decorators';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/backend/src/generated/nestjs-dto/connect-userAccount.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-userAccount.dto.ts
@@ -16,4 +16,11 @@ export class ConnectUserAccountDto {
   @IsOptional()
   @IsString()
   userId?: string;
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  authUid?: string;
 }

--- a/backend/src/modules/users/dto/user-details.dto.ts
+++ b/backend/src/modules/users/dto/user-details.dto.ts
@@ -1,7 +1,10 @@
+import { StaffDetailsDto } from '@/generated/nestjs-dto/staffDetails.dto';
+import { StudentDetailsDto } from '@/generated/nestjs-dto/studentDetails.dto';
+import { UserDetailsDto } from '@/generated/nestjs-dto/userDetails.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { Role } from '@prisma/client';
 
-export class UserDetailsDto {
+export class UserDetailsFullDto {
   @ApiProperty()
   id: string;
 
@@ -20,12 +23,16 @@ export class UserDetailsDto {
   @ApiProperty({ enum: Role })
   role: Role;
 
-  @ApiProperty({ nullable: true, type: Object })
-  userDetails: any;
+  @ApiProperty({ nullable: true, type: UserDetailsDto })
+  userDetails: UserDetailsDto | null;
+}
 
-  @ApiProperty({ nullable: true, type: Object })
-  studentDetails: any;
+export class UserStudentDetailsDto extends UserDetailsFullDto {
+  @ApiProperty({ type: StudentDetailsDto, nullable: true })
+  studentDetails: StudentDetailsDto;
+}
 
-  @ApiProperty({ nullable: true, type: Object })
-  staffDetails: any;
+export class UserStaffDetailsDto extends UserDetailsFullDto {
+  @ApiProperty({ type: StaffDetailsDto, nullable: true })
+  staffDetails: StaffDetailsDto;
 }

--- a/backend/src/modules/users/dto/user-details.dto.ts
+++ b/backend/src/modules/users/dto/user-details.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+
+export class UserDetailsDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty({ nullable: true })
+  email: string | null;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty({ nullable: true })
+  middleName: string | null;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty({ enum: Role })
+  role: Role;
+
+  @ApiProperty({ nullable: true, type: Object })
+  userDetails: any;
+
+  @ApiProperty({ nullable: true, type: Object })
+  studentDetails: any;
+
+  @ApiProperty({ nullable: true, type: Object })
+  staffDetails: any;
+}

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -1,6 +1,5 @@
 import { Roles } from '@/common/decorators/roles.decorator';
 import { Role } from '@/common/enums/roles.enum';
-import { Role as RoleType } from '@prisma/client';
 import { User } from '@/generated/nestjs-dto/user.entity';
 import { InviteUserDto } from '@/modules/users/dto/invite-user.dto';
 import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
@@ -47,7 +46,11 @@ import { Public } from '@/common/decorators/auth.decorator';
 import { StatusBypass } from '@/common/decorators/user-status.decorator';
 import { CurrentUser } from '@/common/decorators/auth-user.decorator';
 import { AuthUser } from '@/common/interfaces/auth.user-metadata';
-import { UserDetailsDto } from './dto/user-details.dto';
+import {
+  UserDetailsFullDto,
+  UserStaffDetailsDto,
+  UserStudentDetailsDto,
+} from './dto/user-details.dto';
 /**
  *
  * @remarks Handles user related operations
@@ -157,21 +160,34 @@ export class UsersController {
   }
 
   /**
-   * Retrieves profile information of the currently authenticated user.
+   * Get the currently authenticated user
    *
    * @remarks
-   * This endpoint uses the `UserDetailsDto` as the response schema.
+   * This endpoint returns the full profile of the currently authenticated user.
+   * The structure of the returned object depends on the user's role:
+   *
+   * - `UserStudentDetailsDto` for users with the `student` role
+   * - `UserStaffDetailsDto` for users with the `mentor` or `admin` role
    */
-  @ApiOkResponse({ type: UserDetailsDto })
+  @ApiExtraModels(UserStudentDetailsDto, UserStaffDetailsDto)
+  @ApiOkResponse({
+    description: 'Current user details fetched successfully',
+    schema: {
+      type: 'object',
+      oneOf: [
+        { $ref: getSchemaPath(UserStudentDetailsDto) },
+        { $ref: getSchemaPath(UserStaffDetailsDto) },
+      ],
+    },
+  })
+  @ApiException(() => [
+    UnauthorizedException,
+    NotFoundException,
+    InternalServerErrorException,
+  ])
   @Get('/me')
   async getMe(@CurrentUser() user: AuthUser) {
-    const id = user.id;
-
-    if (!id) {
-      throw new UnauthorizedException('User not authorized');
-    }
-
-    return this.usersService.getMe(id);
+    return this.usersService.getMe(user);
   }
 
   /**

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -17,6 +17,7 @@ import {
   Put,
   Query,
   Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -30,7 +31,9 @@ import { PaginatedUsersDto } from './dto/paginated-user.dto';
 import { UpdateUserDetailsDto } from './dto/update-user-details.dto';
 import { UserWithRelations } from './dto/user-with-relations.dto';
 import { UsersService } from './users.service';
-
+import { CurrentUser } from '@/common/decorators/auth-user.decorator';
+import { AuthUser } from '@/common/interfaces/auth.user-metadata';
+import { UserDetailsDto } from './dto/user-details.dto';
 /**
  *
  * @remarks Handles user related operations
@@ -83,6 +86,24 @@ export class UsersController {
       if (err instanceof BadRequestException) throw err;
       throw new InternalServerErrorException('Failed to create user');
     }
+  }
+
+  /**
+   * Retrieves profile information of the currently authenticated user.
+   *
+   * @remarks
+   * This endpoint uses the `UserDetailsDto` as the response schema.
+   */
+  @ApiOkResponse({ type: UserDetailsDto })
+  @Get('/me')
+  async getMe(@CurrentUser() user: AuthUser) {
+    const id = user.id;
+
+    if (!id) {
+      throw new UnauthorizedException('User not authorized');
+    }
+
+    return this.usersService.getMe(id);
   }
 
   /**


### PR DESCRIPTION
## This PR introduces the ability to fetch profile information of the currently authenticated user using the Supabase authUid.


### 🔧 Changes:
- Added @unique constraint to UserAccount.authUid in Prisma 
- Implemented UserDetailsDto to return a flattened user profile 
- Added CurrentUser custom decorator to extract authenticated user from 
- Created GET /users/me endpoint in controller using 
- Implemented UsersService.getMe(authUid) to:
  - Fetch UserAccount via authUid
  - Eager-load related entities: user, userDetails, studentDetails, staffDetails
  - Flatten and map data into a structured UserDetailsDto
  - Handle not found and internal errors with proper exceptions