### PR TITLE
[CAP-52] FEAT: Setup n8n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ n8n/database
 n8n/local-files
 n8n/n8n_data
 n8n/tailscale_state
+n8n/**/logs
+n8n/letsencrypt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 node_modules
 .idea
+
+**/.env
+
+# n8n
+n8n/database
+n8n/local-files
+n8n/n8n_data
+n8n/tailscale_state

--- a/n8n/compose.yml
+++ b/n8n/compose.yml
@@ -1,22 +1,26 @@
 services:
-  tailscale:
-    image: tailscale/tailscale:latest
-    container_name: tailscale_n8n
-    hostname: n8n
+  # To prevent mounting docker.sock, which is a security risk
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
     environment:
-      TS_AUTHKEY: ${TS_AUTHKEY}
-      TS_STATE_DIR: /var/lib/tailscale
-      TS_USERSPACE: false
-      TS_SERVE_CONFIG: /config/serve.json
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    cap_add:
-      - net_admin
-      - sys_module
-    restart: unless-stopped
+      CONTAINERS: 1
     volumes:
-      - ${PROJECT_DIR}/tailscale:/config
-      - ${PROJECT_DIR}/tailscale_state:/var/lib/tailscale
+    - /var/run/docker.sock:/var/run/docker.sock
+
+  traefik:
+    image: traefik:latest
+    command:
+    - "--configFile=/etc/traefik/config/static.yml"
+    security_opt:
+    - no-new-privileges:true
+    ports:
+    - "80:80"
+    - "443:443"
+    volumes:
+    - ./letsencrypt:/letsencrypt:rw # letsencrypt folder
+    - ./traefik/config:/etc/traefik/config:ro # traefik folder
+    - ./traefik/logs:/logs # traefik folder
+    restart: always
 
   db:
     image: postgres:16-alpine
@@ -54,7 +58,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    network_mode: service:tailscale
+    # network_mode: service:tailscale
+    labels:
+    - "traefik.enable=true"
+
+    # Router Configuration
+    - "traefik.http.routers.n8n.rule=Host(`${N8N_FQDN}`)"
+    - "traefik.http.routers.n8n.entrypoints=web"
     volumes:
       - ${PROJECT_DIR}/n8n_data:/home/node/.n8n
       - ${PROJECT_DIR}/local-files:/files

--- a/n8n/compose.yml
+++ b/n8n/compose.yml
@@ -1,0 +1,60 @@
+services:
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: tailscale_n8n
+    hostname: n8n
+    environment:
+      TS_AUTHKEY: ${TS_AUTHKEY}
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_USERSPACE: false
+      TS_SERVE_CONFIG: /config/serve.json
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - net_admin
+      - sys_module
+    restart: unless-stopped
+    volumes:
+      - ${PROJECT_DIR}/tailscale:/config
+      - ${PROJECT_DIR}/tailscale_state:/var/lib/tailscale
+
+  db:
+    image: postgres:16-alpine
+    container_name: db
+    restart: unless-stopped
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - ${PROJECT_DIR}/database:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -h localhost -U ${POSTGRES_USER} -d n8n"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  n8n:
+    image: n8nio/n8n:1.106.2
+    container_name: n8n
+    restart: unless-stopped
+    environment:
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_HOST=${POSTGRESDB_HOST}
+      - DB_POSTGRESDB_DATABASE=${POSTGRES_DB}
+      - DB_POSTGRESDB_USER=${POSTGRES_USER}
+      - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+      - NODE_ENV=${NODE_ENV}
+      - WEBHOOK_URL=${WEBHOOK_URL}
+      - NODE_FUNCTION_ALLOW_BUILTIN=*
+    depends_on:
+      db:
+        condition: service_healthy
+    network_mode: service:tailscale
+    volumes:
+      - ${PROJECT_DIR}/n8n_data:/home/node/.n8n
+      - ${PROJECT_DIR}/local-files:/files

--- a/n8n/compose.yml
+++ b/n8n/compose.yml
@@ -8,6 +8,7 @@ services:
     - /var/run/docker.sock:/var/run/docker.sock
 
   traefik:
+    container_name: traefik
     image: traefik:latest
     command:
     - "--configFile=/etc/traefik/config/static.yml"

--- a/n8n/tailscale/serve.json
+++ b/n8n/tailscale/serve.json
@@ -1,0 +1,16 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:5678" 
+        }
+      }
+    }
+  }
+}

--- a/n8n/traefik/config/static.yml
+++ b/n8n/traefik/config/static.yml
@@ -1,0 +1,37 @@
+global:
+  checkNewVersion: true
+  sendAnonymousUsage: false
+
+log:
+  level: DEBUG
+  filePath: /logs/traefik.log
+
+accessLog:
+  filePath: /logs/access.log
+
+entryPoints:
+  web:
+    address: ":80"
+    # http:
+    #   redirections:
+    #     entryPoint:
+    #       to: websecure
+    #       scheme: https
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    watch: true
+    endpoint: "tcp://socket-proxy:2375"
+    exposedByDefault: false
+  file:
+    directory: /etc/traefik/config
+    watch: true
+
+certificatesResolvers:
+  tlsresolver:
+    acme:
+      email: admin@mcube.uk
+      storage: /letsencrypt/acme.json
+      tlsChallenge: true


### PR DESCRIPTION
## Features
- **Docker Compose for n8n**
  - Added `docker-compose.yml` for running n8n in development server.
  - Added traefik as reverse-proxy.

---

### Updates
- Updated `.gitignore` to include n8n-specific folders, preventing unnecessary workflow files from being committed.

### Preview
<img width="950" height="982" alt="image" src="https://github.com/user-attachments/assets/6146711f-5e56-40d0-ba41-e4ed1cb6805c" />