### PR TITLE
[CAP-72]: FEAT BE add unique constraint to Major.name

### DIFF
--- a/backend/prisma/migrations/20250814061203_add_unique_constraint_to_name/migration.sql
+++ b/backend/prisma/migrations/20250814061203_add_unique_constraint_to_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Major` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Major_name_key" ON "Major"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -171,7 +171,7 @@ model Major {
   program   Program  @relation(fields: [programId], references: [id])
   courses   Course[]
 
-  name        String
+  name        String @unique
   description String
 
   /// @DtoReadOnly

--- a/backend/src/generated/nestjs-dto/connect-major.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-major.dto.ts
@@ -1,11 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class ConnectMajorDto {
   @ApiProperty({
     type: 'string',
+    required: false,
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  id: string;
+  id?: string;
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  name?: string;
 }


### PR DESCRIPTION
**Description**  
This PR updates the Prisma schema to enforce a unique constraint on the `name` field of the `Major` model.  

**Purpose:**  
- Prevent duplicate `Major` names in the database.  
- Ensure data integrity at the database level.  

**Changes:**  
- Added `@unique` attribute to `Major.name` in `schema.prisma`.  
- Applied migration to update the database schema.  