### PR TITLE
Change: Add unique constraint to `courseCode` in `Course` model

### DIFF
--- a/backend/prisma/migrations/20250816111219_add_unique_constraint_to_course_course_code/migration.sql
+++ b/backend/prisma/migrations/20250816111219_add_unique_constraint_to_course_course_code/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[courseCode]` on the table `Course` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Course_courseCode_key" ON "Course"("courseCode");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -192,7 +192,7 @@ model Course {
   coreqs   Course[] @relation("CourseCoreq")
   coreqFor Course[] @relation("CourseCoreq")
 
-  courseCode  String
+  courseCode  String @unique
   name        String
   description String
   year        String

--- a/backend/src/generated/nestjs-dto/connect-course.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-course.dto.ts
@@ -1,11 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class ConnectCourseDto {
   @ApiProperty({
     type: 'string',
+    required: false,
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  id: string;
+  id?: string;
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  courseCode?: string;
 }


### PR DESCRIPTION
This PR updates the Prisma schema by adding a `@unique` constraint to the `courseCode` field in the `Course` model.


