### PR TITLE
[CAP-80] FEAT: (BE) Reworked Log and PrismaError Custom Message

### DIFF
--- a/backend/src/common/decorators/extract-args.util.ts
+++ b/backend/src/common/decorators/extract-args.util.ts
@@ -1,0 +1,18 @@
+export type MetaParams = Record<number, string>;
+
+export type ExtractedArgs<A, P extends Record<number, string>> = {
+  [K in keyof P as P[K] & string]: A[Extract<K, keyof A>];
+};
+
+export const extractArgs = <A extends any[], P extends Record<number, string>>(
+  params: P,
+  args: A,
+): ExtractedArgs<A, P> => {
+  const output: any = {};
+
+  for (const key in params) {
+    output[params[key] as string] = args[Number(key) as keyof A];
+  }
+
+  return output;
+};

--- a/backend/src/common/decorators/log-param.decorator.ts
+++ b/backend/src/common/decorators/log-param.decorator.ts
@@ -1,0 +1,21 @@
+export const LOG_PARAM = Symbol('LOG_PARAM');
+
+/**
+ * Parameter decorator for marking method parameters to be included in logging.
+ *
+ * @param paramName - Optional name to assign to this parameter in the log output.
+ * If omitted, the name will default to `param<index>`.
+ */
+export function LogParam(paramName?: string): ParameterDecorator {
+  return (
+    target: Object,
+    propertyKey: string | symbol,
+    parameterIndex: number,
+  ) => {
+    const existingParams: Record<number, string> =
+      Reflect.getMetadata(LOG_PARAM, target, propertyKey) || {};
+
+    existingParams[parameterIndex] = paramName || `param${parameterIndex}`;
+    Reflect.defineMetadata(LOG_PARAM, existingParams, target, propertyKey);
+  };
+}

--- a/backend/src/common/decorators/log.decorator.ts
+++ b/backend/src/common/decorators/log.decorator.ts
@@ -1,117 +1,170 @@
-import { Logger } from '@nestjs/common';
+import { HttpException, Logger } from '@nestjs/common';
+import { extractArgs, ExtractedArgs, MetaParams } from './extract-args.util';
+import { LOG_PARAM } from './log-param.decorator';
 import 'reflect-metadata';
 
-const LOG_PARAM = Symbol('LOG_PARAM');
+/**
+ * Callback type for generating a log message based on method arguments.
+ *
+ * @param args - Keyed arguments (from `@LogParam`).
+ * @returns A string message to log.
+ */
+type ArgsCallback = (args: Record<string, any>) => string;
 
 /**
- * Parameter decorator for marking method parameters to be included in logging.
+ * Callback type for generating a log message when the method succeeds.
  *
- * @param {string} [paramName] - Optional name to assign to this parameter in the log output.
- * If omitted, the name will default to `param<index>`.
+ * @template R - The resolved return type of the method.
+ * @param result - The method's return value (resolved if async).
+ * @param args - Keyed arguments (from `@LogParam`).
+ * @returns A string message to log.
  */
-export function LogParam(paramName?: string): ParameterDecorator {
-  return (
-    target: Object,
-    propertyKey: string | symbol,
-    parameterIndex: number,
-  ) => {
-    const existingParams: Record<number, string> =
-      Reflect.getMetadata(LOG_PARAM, target, propertyKey) || {};
+type SuccessCallback<R> = (result: R, args: Record<string, any>) => string;
 
-    existingParams[parameterIndex] = paramName || `param${parameterIndex}`;
-    Reflect.defineMetadata(LOG_PARAM, existingParams, target, propertyKey);
-  };
-}
+/**
+ * Callback type for generating a log message when the method throws.
+ *
+ * @param error - The thrown error instance.
+ * @param args - Keyed arguments (from `@LogParam`).
+ * @returns A string message to log.
+ */
+type ErrorCallback = (
+  error: HttpException,
+  args: Record<string, any>,
+) => string;
 
 /**
  * Options for the {@link Log} method decorator.
+ *
+ * Each option can be:
+ * - `true`: logs a default stringified message.
+ * - `false`: disables logging for that stage.
+ * - a callback: generates a custom log message with full access to method args and return/error values.
+ *
+ * @template R - The resolved return type of the method.
  */
-interface LogOptions {
+interface LogOptions<R = any> {
   /**
-   * Message template for logging method arguments.
+   * Logs the arguments of the decorated method.
    *
-   * - If `true` (default), all decorated parameters are stringified and logged.
-   * - If `false`, arguments are not logged.
-   * - If a string, the string acts as a template, with `{key}` placeholders
-   *   replaced by parameter values.
+   * - If set to `true`, logs the arguments using the default format (e.g., JSON.stringify).
+   * - If set to a callback, allows customizing the log message.
+   *
+   * **Callback signature:**
+   * ```ts
+   * type ArgsCallback<A extends any[]> = (args: A) => string;
+   * ```
    *
    * @example
-   * // Log all arguments (default)
+   * ```ts
    * logArgsMessage: true
    *
-   * @example
-   * // Disable logging of arguments
-   * logArgsMessage: false
-   *
-   * @example
-   * // Use a template
-   * logArgsMessage: "Called with id={id} and name={name}"
+   * logArgsMessage: (args) => `Called with ${args.length} args: ${args.join(", ")}`
+   * ```
    */
-  logArgsMessage?: string | boolean;
+  logArgsMessage?: boolean | ArgsCallback;
 
   /**
-   * Message template for logging successful return values.
+   * Logs a success message when the method finishes without error.
    *
-   * - If `true` (default), the return value is stringified and logged.
-   * - If `false`, no success log is output.
-   * - If a string, the string acts as a template, with `{key}` placeholders
-   *   replaced by object property values (or `{result}` for primitives).
+   * - If set to `true`, logs a default success message.
+   * - If set to a callback, allows customizing the log message with both args and return value.
+   *
+   * **Callback signature:**
+   * ```ts
+   * type SuccessCallback<A extends any[], R> = (args: A, result: R) => string;
+   * ```
    *
    * @example
-   * // Log the return value (default)
+   * ```ts
    * logSuccessMessage: true
    *
-   * @example
-   * // Disable logging of return values
-   * logSuccessMessage: false
-   *
-   * @example
-   * // Use a template for object return
-   * logSuccessMessage: "User created with id={id}"
-   *
-   * @example
-   * // Use a template for primitive return
-   * logSuccessMessage: "Operation result: {result}"
+   * logSuccessMessage: (args, result) =>
+   *   `Method succeeded with result: ${result} for args: ${JSON.stringify(args)}`
+   * ```
    */
-  logSuccessMessage?: string | boolean;
+  logSuccessMessage?: boolean | SuccessCallback<R>;
+
+  /**
+   * Logs an error message when the method throws.
+   *
+   * - If set to `true`, logs a default error message.
+   * - If set to a callback, allows customizing the log message with args and error details.
+   *
+   * **Callback signature:**
+   * ```ts
+   * type ErrorCallback<A extends any[]> = (args: A, error: unknown) => string;
+   * ```
+   *
+   * @example
+   * ```ts
+   * logErrorMessage: true
+   *
+   * logErrorMessage: (args, error) =>
+   *   `Error "${(error as Error).message}" occurred with args: ${JSON.stringify(args)}`
+   * ```
+   */
+  logErrorMessage?: boolean | ErrorCallback;
 }
 
 /**
- * Method decorator for logging method arguments and return values.
+ * Method decorator for logging method arguments, successful results, and errors.
  *
- * Uses `@LogParam` to determine which arguments to log. Also supports
- * templated messages with `{key}` placeholders for both arguments and return values.
+ * Uses {@link LogParam} to determine which arguments to log by key, while
+ * also providing access to the full raw arguments array. Developers can
+ * choose to enable/disable each logging stage or provide custom callbacks
+ * for precise control over the logged messages.
  *
- * @param {LogOptions} options - Configuration for logging behavior.
+ * @template T - The method signature type being decorated.
+ * @param options - Logging configuration.
+ *
+ * @example
+ * ```
+ * class UserService {
+ *  ‎@Log({
+ *     logArgsMessage: (args) => `Fetching user with id=${args.id}`,
+ *     logSuccessMessage: (result) => `User found: ${result.name}`,
+ *     logErrorMessage: (error, args) => `Failed to fetch user ${args.id}: ${error.message}`
+ *   })
+ *   getUser(@LogParam("id") userId: string) {
+ *     return { id: userId, name: "John" };
+ *   }
+ * }
+ * ```
  */
-export function Log(options: LogOptions): MethodDecorator {
-  const { logArgsMessage = true, logSuccessMessage = true } = options;
+export function Log<T extends (...args: Parameters<T>) => any>(
+  options: LogOptions<Awaited<ReturnType<T>>>,
+) {
+  const {
+    logArgsMessage = true,
+    logSuccessMessage = true,
+    logErrorMessage = true,
+  } = options;
 
-  return (
+  return function (
     target: Object | Function,
     propertyKey: string,
-    descriptor: PropertyDescriptor,
-  ) => {
-    const originalMethod = descriptor.value;
+    descriptor: TypedPropertyDescriptor<T>,
+  ) {
+    const originalMethod = descriptor.value!;
 
-    descriptor.value = async function (...args: any[]) {
-      const logger = new Logger(target.constructor?.name || 'UnknownClass');
+    type Args = Parameters<T>;
+    type Ret = Awaited<ReturnType<T>>;
+
+    descriptor.value = async function (...args: Args): Promise<Ret> {
+      const logger = new Logger(target.constructor.name || 'UnknownClass');
+
+      let params: MetaParams = {};
+      let keyArgs: ExtractedArgs<Args, MetaParams> = {};
 
       if (logArgsMessage) {
-        const params: Record<number, string> = Reflect.getMetadata(
-          LOG_PARAM,
-          target,
-          propertyKey,
-        );
-
-        const keyArgs = extractArgs(params, args);
+        params = Reflect.getMetadata(LOG_PARAM, target, propertyKey);
+        keyArgs = extractArgs(params, args); // I cannot extract the type due to the arg's name not retrievable
 
         if (logArgsMessage === true) {
           logger.log(`[${propertyKey}] START: ${JSON.stringify(keyArgs)}`);
         } else {
-          logger.log(
-            `[${propertyKey}] START: ${JSON.stringify(applyTemplate(logArgsMessage, keyArgs))}`,
-          );
+          logger.log(`[${propertyKey}] START: ${logArgsMessage(keyArgs)}`);
         }
       }
 
@@ -122,86 +175,34 @@ export function Log(options: LogOptions): MethodDecorator {
           if (logSuccessMessage === true) {
             logger.log(`[${propertyKey}] SUCCESS: ${JSON.stringify(result)}`);
           } else {
-            if (result !== null && typeof result === 'object') {
-              logger.log(
-                `[${propertyKey}] SUCCESS: ${applyTemplate(logSuccessMessage, result)}`,
-              );
-            } else {
-              logger.log(
-                `[${propertyKey}] SUCCESS: ${JSON.stringify(applyTemplate(logSuccessMessage, { result }))}`,
-              );
-            }
+            logger.log(
+              `[${propertyKey}] SUCCESS: ${logSuccessMessage(result, keyArgs)}`,
+            );
           }
         }
 
         return result;
-      } catch (err) {
-        logger.error(`[${propertyKey}] FAIL: ${err.message}`);
-        throw err;
+      } catch (error) {
+        if (logErrorMessage) {
+          if (!logArgsMessage) {
+            params = Reflect.getMetadata(LOG_PARAM, target, propertyKey);
+            keyArgs = extractArgs(params, args);
+          }
+
+          if (logErrorMessage === true) {
+            logger.error(
+              `[${propertyKey}] FAIL: ${JSON.stringify((error as any).message)}`,
+            );
+          } else {
+            logger.error(
+              `[${propertyKey}] FAIL: ${logErrorMessage(error, keyArgs)}`,
+            );
+          }
+        }
+        throw error;
       }
-    };
+    } as T;
 
     return descriptor;
   };
 }
-
-function extractArgs(
-  params: Record<number, string>,
-  args: any[],
-): Record<string, any> {
-  const output: Record<string, any> = {};
-
-  for (const key of Object.keys(params)) {
-    output[params[key]] = args[key];
-  }
-  return output;
-}
-
-function applyTemplate(template: string, values: Record<string, any>): string {
-  return template.replace(/{([\w.]+)}/g, (_, keyPath) => {
-    const keys = keyPath.split('.');
-    let result: any = values;
-
-    for (const k of keys) {
-      if (result != null && typeof result === 'object' && k in result) {
-        result = result[k];
-      } else {
-        return `{${keyPath}}`;
-      }
-    }
-
-    return String(result);
-  });
-}
-
-// Example on how decorators work
-
-// export function Sample(): MethodDecorator {
-//   return (
-//     target: Object | Function,
-//     propertyKey: string,
-//     descriptor: PropertyDescriptor,
-//   ) => {
-//     // Reference nung original method na pinaglagyan ng decorator
-//     const originalMethod = descriptor.value;
-
-//     // Etong descriptor.value is yung parang ihihighjack mo yung method para makagawa ng HoM
-//     descriptor.value = async function (...args: any[]) {
-//       const logger = new Logger(target.constructor?.name || 'UnknownClass');
-
-//       // Logging before mag run yung component
-//       logger.log(`[${propertyKey}] START:`);
-
-//       // Eto yung component na nilagyan mo ng decorator
-//       const result = await originalMethod.apply(this, args);
-
-//       // Logging after mag run yung component
-//       logger.log(`[${propertyKey}] SUCCESS:`);
-
-//       // Return para ipasa sa next decorator
-//       return result;
-//     };
-
-//     return descriptor;
-//   };
-// }

--- a/backend/src/modules/test/test.service.ts
+++ b/backend/src/modules/test/test.service.ts
@@ -1,4 +1,4 @@
-import { Log, LogParam } from '@/common/decorators/log.decorator';
+import { Log } from '@/common/decorators/log.decorator';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { TestBodyDto } from './dto/test-body.dto';
 import {
@@ -6,28 +6,34 @@ import {
   PrismaErrorCode,
 } from '@/common/decorators/prisma-error.decorator';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { LogParam } from '@/common/decorators/log-param.decorator';
 
 @Injectable()
 export class TestService {
   constructor() {}
 
   @Log({
-    logArgsMessage: 'Hello from id={id} and {data.nested.name}',
-    logSuccessMessage: 'Hello to {nested.name}',
+    logArgsMessage: ({ id }) => `${id}`,
+    logSuccessMessage: (data) => `Hello to ${data.id}`,
+    logErrorMessage: (err, { id }) =>
+      `There was an error for id=${id}: ${err.message}`,
   })
   @PrismaError({
-    [PrismaErrorCode.UniqueConstraint]: () =>
-      new BadRequestException('Http error because user not found'),
+    [PrismaErrorCode.UniqueConstraint]: (msg, { id }) =>
+      new BadRequestException(`Http error because user not found at id=${id}`),
   })
   async test(
     @LogParam('id') id: string,
     page: number,
     @LogParam('data') data: TestBodyDto,
   ) {
-    // throw new PrismaClientKnownRequestError('This is Prisma Error Due to missing Id', {
-    //   clientVersion: '6.13.0',
-    //   code: 'P2002',
-    // });
+    // throw new PrismaClientKnownRequestError(
+    //   'This is Prisma Error Due to missing Id',
+    //   {
+    //     clientVersion: '6.13.0',
+    //     code: 'P2002',
+    //   },
+    // );
     return data;
   }
 }


### PR DESCRIPTION
- Added logErrorMessage for `@Log()` decorator to have custom message for error logs
- Reworked `@Log()` messages to use callback instead of templates to provide a more flexible way of adding custom data to messages
- Added args to the callback param of `@PrismaError()` decorator
- Moved some functions to a separate file like the `@LogParam()` and `extractArgs()` functions
- Modified the `test()` method in TestService to test out the new functionality