### PR TITLE
[CAP-102] FIX: (BE) Resolve Circular References in Swagger DTOs

### DIFF
--- a/backend/src/modules/courses/courses.controller.ts
+++ b/backend/src/modules/courses/courses.controller.ts
@@ -21,8 +21,8 @@ import { DeleteQueryDto } from '@/common/dto/delete-query.dto';
 import { Roles } from '@/common/decorators/roles.decorator';
 import { Role } from '@/common/enums/roles.enum';
 import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
-import { Course } from '@/generated/nestjs-dto/course.entity';
 import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
+import { CourseDto } from './dto/course.dto';
 
 /**
  * @remarks
@@ -40,7 +40,7 @@ export class CoursesController {
    * Requires `ADMIN` role.
    *
    */
-  @ApiCreatedResponse({ type: Course })
+  @ApiCreatedResponse({ type: CourseDto })
   @ApiException(() => [ConflictException, InternalServerErrorException])
   @Roles(Role.ADMIN)
   @Post()
@@ -67,7 +67,7 @@ export class CoursesController {
    * @remarks Requires `ADMIN` role.
    *
    */
-  @ApiOkResponse({ type: Course })
+  @ApiOkResponse({ type: CourseDto })
   @ApiException(() => [NotFoundException, InternalServerErrorException])
   @Roles(Role.ADMIN)
   @Get(':id')
@@ -82,7 +82,7 @@ export class CoursesController {
    * This operation updates the details of an existing course.
    * Requires `ADMIN` role.
    */
-  @ApiOkResponse({ type: Course })
+  @ApiOkResponse({ type: CourseDto })
   @ApiException(() => [
     NotFoundException,
     ConflictException,

--- a/backend/src/modules/courses/courses.service.ts
+++ b/backend/src/modules/courses/courses.service.ts
@@ -1,11 +1,9 @@
-import { CourseDto } from '@/generated/nestjs-dto/course.dto';
 import { ExtendedPrismaClient } from '@/lib/prisma/prisma.extension';
 import {
   BadRequestException,
   ConflictException,
   Inject,
   Injectable,
-  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { CustomPrismaService } from 'nestjs-prisma';
@@ -21,11 +19,10 @@ import {
   PrismaError,
   PrismaErrorCode,
 } from '@/common/decorators/prisma-error.decorator';
+import { CourseDto } from './dto/course.dto';
 
 @Injectable()
 export class CoursesService {
-  private readonly logger = new Logger(CoursesService.name);
-
   constructor(
     @Inject('PrismaService')
     private prisma: CustomPrismaService<ExtendedPrismaClient>,
@@ -74,7 +71,7 @@ export class CoursesService {
       data.coreqs = { connect: coreqIds.map((id) => ({ id })) };
     }
 
-    return await this.prisma.client.course.create({ data });
+    return (await this.prisma.client.course.create({ data })) as CourseDto;
   }
 
   /**
@@ -164,7 +161,7 @@ export class CoursesService {
       throw new BadRequestException('Invalid course ID format');
     }
 
-    return await this.prisma.client.course.findUniqueOrThrow({
+    return (await this.prisma.client.course.findUniqueOrThrow({
       where: { id },
       include: {
         coreqs: {
@@ -174,7 +171,7 @@ export class CoursesService {
           select: { id: true, courseCode: true, name: true },
         },
       },
-    });
+    })) as CourseDto;
   }
 
   /**
@@ -227,7 +224,10 @@ export class CoursesService {
       data.prereqs = { set: prereqIds.map((id) => ({ id })) };
     }
 
-    return await this.prisma.client.course.update({ where: { id }, data });
+    return (await this.prisma.client.course.update({
+      where: { id },
+      data,
+    })) as CourseDto;
   }
 
   /**

--- a/backend/src/modules/courses/dto/course.dto.ts
+++ b/backend/src/modules/courses/dto/course.dto.ts
@@ -1,0 +1,27 @@
+import { CourseDto as AutoCourseDto } from '@/generated/nestjs-dto/course.dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CourseRelationDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  courseCode: string;
+
+  @ApiProperty()
+  name: string;
+}
+
+export class CourseDto extends AutoCourseDto {
+  @ApiProperty({ type: () => [CourseRelationDto] })
+  prereqs: CourseRelationDto[];
+
+  @ApiProperty({ type: () => [CourseRelationDto] })
+  prereqFor: CourseRelationDto[];
+
+  @ApiProperty({ type: () => [CourseRelationDto] })
+  coreqs: CourseRelationDto[];
+
+  @ApiProperty({ type: () => [CourseRelationDto] })
+  coreqFor: CourseRelationDto[];
+}

--- a/backend/src/modules/major/dto/create-major.dto.ts
+++ b/backend/src/modules/major/dto/create-major.dto.ts
@@ -1,21 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, IsUUID, ValidateNested } from 'class-validator';
-import { CreateMajorDto as GeneratedCreateMajorDto } from '@/generated/nestjs-dto/create-major.dto';
+import { CreateMajorDto } from '@/generated/nestjs-dto/create-major.dto';
 import { Type } from 'class-transformer';
 
-export class CreateMajorDto {
-  @ApiProperty({
-    type: GeneratedCreateMajorDto,
-  })
+export class CreateProgramMajorDto {
+  @ApiProperty({ type: () => CreateMajorDto })
   @ValidateNested()
-  @Type(() => GeneratedCreateMajorDto)
-  major: GeneratedCreateMajorDto;
+  @Type(() => CreateMajorDto)
+  major: CreateMajorDto;
 
   @ApiProperty({
     type: 'string',
+    format: 'uuid',
   })
-  @IsString()
-  @IsNotEmpty()
   @IsUUID()
+  @IsNotEmpty()
   programId: string;
 }

--- a/backend/src/modules/major/major.controller.ts
+++ b/backend/src/modules/major/major.controller.ts
@@ -23,7 +23,7 @@ import { PaginatedMajorsDto } from './dto/paginated-major.dto';
 import { Roles } from '@/common/decorators/roles.decorator';
 import { Role } from '@/common/enums/roles.enum';
 import { BaseFilterDto } from '@/common/dto/base-filter.dto';
-import { CreateMajorDto } from './dto/create-major.dto';
+import { CreateProgramMajorDto } from './dto/create-major.dto';
 
 /**
  * @remarks
@@ -46,8 +46,8 @@ export class MajorController {
   @ApiCreatedResponse({ type: Major })
   @ApiException(() => ConflictException)
   @ApiException(() => [ConflictException, InternalServerErrorException])
-  create(@Body() createMajorDto: CreateMajorDto) {
-    return this.majorService.create(createMajorDto);
+  create(@Body() createProgramMajorDto: CreateProgramMajorDto) {
+    return this.majorService.create(createProgramMajorDto);
   }
 
   /**

--- a/backend/src/modules/major/major.service.ts
+++ b/backend/src/modules/major/major.service.ts
@@ -15,7 +15,7 @@ import { PaginatedMajorsDto } from './dto/paginated-major.dto';
 import { MajorDto } from '@/generated/nestjs-dto/major.dto';
 import { isUUID } from 'class-validator';
 import { BaseFilterDto } from '@/common/dto/base-filter.dto';
-import { CreateMajorDto } from './dto/create-major.dto';
+import { CreateProgramMajorDto } from './dto/create-major.dto';
 
 @Injectable()
 export class MajorService {
@@ -30,20 +30,22 @@ export class MajorService {
    * Creates a new academic major in the database.
    *
    * @async
-   * @param {CreateMajorDto} createMajorDto - Data Transfer Object containing major details to create.
+   * @param {CreateProgramMajorDto} createProgramMajorDto - Data Transfer Object containing major details to create.
    * @returns {Promise<MajorDto>} The created major record.
    *
    * @throws {ConflictException} - If the major name already exists.
    * @throws {Error} Any other unexpected errors.
    */
-  async create(createMajorDto: CreateMajorDto): Promise<MajorDto> {
+  async create(
+    createProgramMajorDto: CreateProgramMajorDto,
+  ): Promise<MajorDto> {
     try {
       const major = await this.prisma.client.major.create({
         data: {
-          name: createMajorDto.major.name,
-          description: createMajorDto.major.description,
+          name: createProgramMajorDto.major.name,
+          description: createProgramMajorDto.major.description,
           program: {
-            connect: { id: createMajorDto.programId },
+            connect: { id: createProgramMajorDto.programId },
           },
         },
       });


### PR DESCRIPTION
## Summary
This PR addresses circular reference issues in both **Major DTOs** and **Course DTOs** that were causing problems in Swagger schema generation and validation.  The changes ensure cleaner DTO structures, prevent self-referencing loops, and improve compatibility with Swagger.

---

## Changes

### Major DTOs
- Replaced `CreateMajorDto` with `CreateProgramMajorDto` to break circular dependency.
- Updated Swagger decorators to use `() => CreateMajorDto` instead of direct reference.
- Adjusted `MajorService` and `MajorController` to accept `CreateProgramMajorDto` in the `create` method.
- Added `format: 'uuid'` to `programId` property for correct Swagger schema validation.
- Ensured DTO structure avoids self-referencing loops in Swagger generation.

### Course DTOs
- Introduced `CourseRelationDto` to represent minimal course fields in relations.
- Extended generated `CourseDto` with relation fields (`prereqs`, `prereqFor`, `coreqs`, `coreqFor`) using `CourseRelationDto[]`.
- Updated `CoursesService` return types to cast Prisma results as `CourseDto`.
- Replaced usage of generated `Course` entity in controller Swagger decorators with new `CourseDto`.
- Ensured Swagger schema avoids self-referencing loops by decoupling relation properties.