### PR TITLE
CAP-134 Refactor: [Schema] update course and module relations

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -172,11 +172,11 @@ model Program {
   /// @DtoApiHidden
   majors Major[]
 
-  programCode String @unique
-  name        String @unique
-  description String
-  yearDuration    Int
-  isActive    Boolean @default(true)
+  programCode  String  @unique
+  name         String  @unique
+  description  String
+  yearDuration Int
+  isActive     Boolean @default(true)
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -198,8 +198,8 @@ model Major {
   /// @DtoApiHidden
   curriculums Curriculum[]
 
-  majorCode   String @unique
-  name        String @unique
+  majorCode   String  @unique
+  name        String  @unique
   description String
   isActive    Boolean @default(true)
 
@@ -215,7 +215,7 @@ model Course {
   id String @id @default(uuid()) @db.Uuid
 
   /// @DtoApiHidden
-  major Major[]
+  majors Major[]
 
   prereqs   Course[] @relation("CoursePrereq")
   prereqFor Course[] @relation("CoursePrereq")
@@ -225,7 +225,7 @@ model Course {
 
   curriculumCourses CurriculumCourse[]
 
-  courseCode  String @unique
+  courseCode  String  @unique
   name        String
   description String
   units       Int
@@ -234,6 +234,8 @@ model Course {
 
   /// @DtoApiHidden
   courseOfferings CourseOffering[] // A course can have multiple offerings
+  /// @DtoApiHidden 
+  modules         Module[]
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -334,9 +336,12 @@ model CourseOffering {
   /// @DtoApiHidden
   enrollmentPeriod EnrollmentPeriod @relation(fields: [periodId], references: [id])
 
-  courseEnrollment CourseEnrollment[] // Each offering can have multiple enrollments
-
-  courseSections CourseSection[] // Each offering can have multiple sections
+  /// @DtoApiHidden
+  courseEnrollments CourseEnrollment[] // Each offering can have multiple enrollments
+  /// @DtoApiHidden
+  courseSections    CourseSection[] // Each offering can have multiple sections
+  /// @DtoApiHidden
+  modules           Module[]
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -406,11 +411,9 @@ model CourseEnrollment {
   /// @DtoApiHidden
   courseSection   CourseSection @relation(fields: [courseSectionId], references: [id])
 
-  studentId String   @db.Uuid // Each enrolled course belong to one user i.e student
+  studentId String @db.Uuid // Each enrolled course belong to one user i.e student
   /// @DtoApiHidden
-  user      User     @relation(fields: [studentId], references: [id])
-  /// @DtoApiHidden
-  Module    Module[]
+  user      User   @relation(fields: [studentId], references: [id])
 
   status      CourseEnrollmentStatus
   startedAt   DateTime
@@ -526,8 +529,11 @@ model Module {
   id    String @id @default(uuid()) @db.Uuid
   title String
 
-  courseEnrollmentId String           @db.Uuid
-  courseEnrollment   CourseEnrollment @relation(fields: [courseEnrollmentId], references: [id])
+  courseId String @db.Uuid
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
+
+  courseOfferingId String?         @db.Uuid
+  courseOffering   CourseOffering? @relation(fields: [courseOfferingId], references: [id], onDelete: Cascade)
 
   publishedAt DateTime?
   toPublishAt DateTime?
@@ -565,6 +571,13 @@ model ModuleSection {
 
   publishedBy String? @db.Uuid
   user        User?   @relation(fields: [publishedBy], references: [id])
+
+  /// @DtoReadOnly
+  createdAt DateTime  @default(now())
+  /// @DtoReadOnly
+  updatedAt DateTime  @updatedAt
+  /// @DtoReadOnly
+  deletedAt DateTime?
 }
 
 enum ContentType {
@@ -572,13 +585,15 @@ enum ContentType {
   DISCUSSION
   ASSIGNMENT
   REFLECTION
+  URL
+  FILE
 }
 
 model ModuleContent {
-  id       String @id @default(uuid()) @db.Uuid
+  id       String  @id @default(uuid()) @db.Uuid
   order    Int
   title    String
-  subtitle String
+  subtitle String?
 
   moduleSectionId String        @db.Uuid
   moduleSection   ModuleSection @relation(fields: [moduleSectionId], references: [id], onDelete: Cascade)

--- a/backend/src/generated/nestjs-dto/course.entity.ts
+++ b/backend/src/generated/nestjs-dto/course.entity.ts
@@ -8,6 +8,7 @@ import {
   CourseOffering,
   type CourseOffering as CourseOfferingAsType,
 } from './courseOffering.entity';
+import { Module, type Module as ModuleAsType } from './module.entity';
 
 export class Course {
   @ApiProperty({
@@ -15,7 +16,7 @@ export class Course {
   })
   id: string;
   @ApiHideProperty()
-  major?: MajorAsType[];
+  majors?: MajorAsType[];
   @ApiProperty({
     type: () => Course,
     isArray: true,
@@ -73,6 +74,8 @@ export class Course {
   isActive: boolean;
   @ApiHideProperty()
   courseOfferings?: CourseOfferingAsType[];
+  @ApiHideProperty()
+  modules?: ModuleAsType[];
   @ApiProperty({
     type: 'string',
     format: 'date-time',

--- a/backend/src/generated/nestjs-dto/courseEnrollment.entity.ts
+++ b/backend/src/generated/nestjs-dto/courseEnrollment.entity.ts
@@ -9,7 +9,6 @@ import {
   type CourseSection as CourseSectionAsType,
 } from './courseSection.entity';
 import { User, type User as UserAsType } from './user.entity';
-import { Module, type Module as ModuleAsType } from './module.entity';
 
 export class CourseEnrollment {
   @ApiProperty({
@@ -34,8 +33,6 @@ export class CourseEnrollment {
   studentId: string;
   @ApiHideProperty()
   user?: UserAsType;
-  @ApiHideProperty()
-  Module?: ModuleAsType[];
   @ApiProperty({
     enum: CourseEnrollmentStatus,
     enumName: 'CourseEnrollmentStatus',

--- a/backend/src/generated/nestjs-dto/courseOffering.entity.ts
+++ b/backend/src/generated/nestjs-dto/courseOffering.entity.ts
@@ -12,6 +12,7 @@ import {
   CourseSection,
   type CourseSection as CourseSectionAsType,
 } from './courseSection.entity';
+import { Module, type Module as ModuleAsType } from './module.entity';
 
 export class CourseOffering {
   @ApiProperty({
@@ -30,18 +31,12 @@ export class CourseOffering {
   periodId: string;
   @ApiHideProperty()
   enrollmentPeriod?: EnrollmentPeriodAsType;
-  @ApiProperty({
-    type: () => CourseEnrollment,
-    isArray: true,
-    required: false,
-  })
-  courseEnrollment?: CourseEnrollmentAsType[];
-  @ApiProperty({
-    type: () => CourseSection,
-    isArray: true,
-    required: false,
-  })
+  @ApiHideProperty()
+  courseEnrollments?: CourseEnrollmentAsType[];
+  @ApiHideProperty()
   courseSections?: CourseSectionAsType[];
+  @ApiHideProperty()
+  modules?: ModuleAsType[];
   @ApiProperty({
     type: 'string',
     format: 'date-time',

--- a/backend/src/generated/nestjs-dto/create-moduleContent.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-moduleContent.dto.ts
@@ -25,10 +25,12 @@ export class CreateModuleContentDto {
   title: string;
   @ApiProperty({
     type: 'string',
+    required: false,
+    nullable: true,
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  subtitle: string;
+  subtitle?: string | null;
   @ApiProperty({
     type: () => Object,
   })

--- a/backend/src/generated/nestjs-dto/module.entity.ts
+++ b/backend/src/generated/nestjs-dto/module.entity.ts
@@ -1,8 +1,9 @@
 import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Course, type Course as CourseAsType } from './course.entity';
 import {
-  CourseEnrollment,
-  type CourseEnrollment as CourseEnrollmentAsType,
-} from './courseEnrollment.entity';
+  CourseOffering,
+  type CourseOffering as CourseOfferingAsType,
+} from './courseOffering.entity';
 import { User, type User as UserAsType } from './user.entity';
 import {
   ModuleSection,
@@ -21,12 +22,23 @@ export class Module {
   @ApiProperty({
     type: 'string',
   })
-  courseEnrollmentId: string;
+  courseId: string;
   @ApiProperty({
-    type: () => CourseEnrollment,
+    type: () => Course,
     required: false,
   })
-  courseEnrollment?: CourseEnrollmentAsType;
+  course?: CourseAsType;
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+  })
+  courseOfferingId: string | null;
+  @ApiProperty({
+    type: () => CourseOffering,
+    required: false,
+    nullable: true,
+  })
+  courseOffering?: CourseOfferingAsType | null;
   @ApiProperty({
     type: 'string',
     format: 'date-time',

--- a/backend/src/generated/nestjs-dto/moduleContent.dto.ts
+++ b/backend/src/generated/nestjs-dto/moduleContent.dto.ts
@@ -17,8 +17,9 @@ export class ModuleContentDto {
   title: string;
   @ApiProperty({
     type: 'string',
+    nullable: true,
   })
-  subtitle: string;
+  subtitle: string | null;
   @ApiProperty({
     type: () => Object,
   })

--- a/backend/src/generated/nestjs-dto/moduleContent.entity.ts
+++ b/backend/src/generated/nestjs-dto/moduleContent.entity.ts
@@ -34,8 +34,9 @@ export class ModuleContent {
   title: string;
   @ApiProperty({
     type: 'string',
+    nullable: true,
   })
-  subtitle: string;
+  subtitle: string | null;
   @ApiProperty({
     type: 'string',
   })

--- a/backend/src/generated/nestjs-dto/moduleSection.dto.ts
+++ b/backend/src/generated/nestjs-dto/moduleSection.dto.ts
@@ -17,4 +17,20 @@ export class ModuleSectionDto {
     nullable: true,
   })
   toPublishAt: Date | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
+  deletedAt: Date | null;
 }

--- a/backend/src/generated/nestjs-dto/moduleSection.entity.ts
+++ b/backend/src/generated/nestjs-dto/moduleSection.entity.ts
@@ -62,4 +62,20 @@ export class ModuleSection {
     nullable: true,
   })
   user?: UserAsType | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
+  deletedAt: Date | null;
 }

--- a/backend/src/generated/nestjs-dto/update-moduleContent.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-moduleContent.dto.ts
@@ -27,10 +27,11 @@ export class UpdateModuleContentDto {
   @ApiProperty({
     type: 'string',
     required: false,
+    nullable: true,
   })
   @IsOptional()
   @IsString()
-  subtitle?: string;
+  subtitle?: string | null;
   @ApiProperty({
     type: () => Object,
     required: false,


### PR DESCRIPTION
# Description
This PR refactors the schema relations between `Course`, `CourseOffering`, and `Module`, and updates related models for clarity and consistency.

### Changes
- Rename `Course.major` to `Course.majors`
- Add `Course.modules` with `@DtoApiHidden`
- Annotate `CourseOffering.courseEnrollments` and `CourseOffering.courseSections` with `@DtoApiHidden`
- Add `modules` back reference to `CourseOffering`
- Remove `modules` back reference from `CourseEnrollment`
- Add `courseId`, `course`, `courseOfferingId`, `courseOffering` to `Module`
- Add timestamp fields (`createdAt`, `updatedAt`, `deletedAt`) to `ModuleSection`
- Add `ContentType.URL` and `ContentType.FILE`
- Make `ModuleContent.subtitle` optional