### PR TITLE
[CAP-162-164] Feat: (BE) Implement LmsSectionService/Controller and update models

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -39,35 +39,37 @@ enum UserStatus {
 }
 
 model User {
-  id                   String             @id @default(uuid()) @db.Uuid
+  id                    String                  @id @default(uuid()) @db.Uuid
   /// @DtoApiHidden
-  userAccount          UserAccount?
+  userAccount           UserAccount?
   /// @DtoApiHidden
-  userDetails          UserDetails?
+  userDetails           UserDetails?
   /// @DtoApiHidden
-  studentDetails       StudentDetails?
+  studentDetails        StudentDetails?
   /// @DtoApiHidden
-  staffDetails         StaffDetails?
+  staffDetails          StaffDetails?
   /// @DtoApiHidden
-  bills                Bill[]
+  bills                 Bill[]
   /// @DtoApiHidden
-  notifications        Notification[]
+  notifications         Notification[]
   /// @DtoApiHidden
-  courseEnrollment     CourseEnrollment[]
+  courseEnrollment      CourseEnrollment[]
   /// @DtoApiHidden
-  courseSections       CourseSection[]
+  courseSections        CourseSection[]
   /// @DtoApiHidden
-  submittedSubmissions Submission[]       @relation("SubmissionStudent")
+  submittedSubmissions  Submission[]            @relation("SubmissionStudent")
   /// @DtoApiHidden
-  gradedSubmissions    Submission[]       @relation("SubmissionGrader")
+  gradedSubmissions     Submission[]            @relation("SubmissionGrader")
   /// @DtoApiHidden
-  moduleProgress       ContentProgress[]
+  moduleProgress        ContentProgress[]
   /// @DtoApiHidden
-  publishedModules     Module[]
+  publishedModules      Module[]
   /// @DtoApiHidden
-  publishedSections    ModuleSection[]
+  publishedSections     ModuleSection[]
   /// @DtoApiHidden
-  publishedContents    ModuleContent[]
+  publishedContents     ModuleContent[]
+  /// @DtoApiHidden
+  moduleSectionProgress ModuleSectionProgress[]
 
   firstName  String
   middleName String?
@@ -577,6 +579,12 @@ model ModuleSection {
   /// @DtoApiHidden
   subsections     ModuleSection[] @relation("ModuleSubsection")
 
+  prerequisiteSectionId String?         @db.Uuid
+  /// @DtoApiHidden
+  prerequisiteSection   ModuleSection?  @relation("ModulePrerequisite", fields: [prerequisiteSectionId], references: [id])
+  /// @DtoApiHidden
+  dependentSections     ModuleSection[] @relation("ModulePrerequisite")
+
   /// @DtoApiHidden
   moduleContents ModuleContent[]
 
@@ -591,17 +599,38 @@ model ModuleSection {
   publishedByUser User?   @relation(fields: [publishedBy], references: [id])
 
   /// @DtoReadOnly
-  createdAt DateTime  @default(now())
+  createdAt             DateTime                @default(now())
   /// @DtoReadOnly
-  updatedAt DateTime  @updatedAt
+  updatedAt             DateTime                @updatedAt
   /// @DtoReadOnly
-  deletedAt DateTime?
+  deletedAt             DateTime?
+  ModuleSectionProgress ModuleSectionProgress[]
 
   @@unique([moduleId, order]) // ensure unique order within module
   @@index([moduleId])
   @@index([parentSectionId])
   @@index([order])
   @@index([publishedAt])
+}
+
+model ModuleSectionProgress {
+  id String @id @default(uuid()) @db.Uuid
+
+  userId String @db.Uuid
+  user   User   @relation(fields: [userId], references: [id])
+
+  moduleSectionId String        @db.Uuid
+  moduleSection   ModuleSection @relation(fields: [moduleSectionId], references: [id])
+
+  completedAt DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, moduleSectionId])
+  @@index([userId])
+  @@index([moduleSectionId])
+  @@index([completedAt])
 }
 
 enum ContentType {

--- a/backend/src/generated/nestjs-dto/connect-moduleSectionProgress.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-moduleSectionProgress.dto.ts
@@ -1,0 +1,42 @@
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ModuleSectionProgressUserIdModuleSectionIdUniqueInputDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+  @ApiProperty({
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  moduleSectionId: string;
+}
+
+@ApiExtraModels(ModuleSectionProgressUserIdModuleSectionIdUniqueInputDto)
+export class ConnectModuleSectionProgressDto {
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  id?: string;
+  @ApiProperty({
+    type: ModuleSectionProgressUserIdModuleSectionIdUniqueInputDto,
+    required: false,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ModuleSectionProgressUserIdModuleSectionIdUniqueInputDto)
+  userId_moduleSectionId?: ModuleSectionProgressUserIdModuleSectionIdUniqueInputDto;
+}

--- a/backend/src/generated/nestjs-dto/create-moduleSectionProgress.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-moduleSectionProgress.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class CreateModuleSectionProgressDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsDateString()
+  completedAt?: Date | null;
+}

--- a/backend/src/generated/nestjs-dto/moduleSection.entity.ts
+++ b/backend/src/generated/nestjs-dto/moduleSection.entity.ts
@@ -5,6 +5,10 @@ import {
   type ModuleContent as ModuleContentAsType,
 } from './moduleContent.entity';
 import { User, type User as UserAsType } from './user.entity';
+import {
+  ModuleSectionProgress,
+  type ModuleSectionProgress as ModuleSectionProgressAsType,
+} from './moduleSectionProgress.entity';
 
 export class ModuleSection {
   @ApiProperty({
@@ -26,6 +30,15 @@ export class ModuleSection {
   parentSection?: ModuleSection | null;
   @ApiHideProperty()
   subsections?: ModuleSection[];
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+  })
+  prerequisiteSectionId: string | null;
+  @ApiHideProperty()
+  prerequisiteSection?: ModuleSection | null;
+  @ApiHideProperty()
+  dependentSections?: ModuleSection[];
   @ApiHideProperty()
   moduleContents?: ModuleContentAsType[];
   @ApiProperty({
@@ -72,4 +85,10 @@ export class ModuleSection {
     nullable: true,
   })
   deletedAt: Date | null;
+  @ApiProperty({
+    type: () => ModuleSectionProgress,
+    isArray: true,
+    required: false,
+  })
+  ModuleSectionProgress?: ModuleSectionProgressAsType[];
 }

--- a/backend/src/generated/nestjs-dto/moduleSectionProgress.dto.ts
+++ b/backend/src/generated/nestjs-dto/moduleSectionProgress.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ModuleSectionProgressDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
+  completedAt: Date | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/moduleSectionProgress.entity.ts
+++ b/backend/src/generated/nestjs-dto/moduleSectionProgress.entity.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User, type User as UserAsType } from './user.entity';
+import {
+  ModuleSection,
+  type ModuleSection as ModuleSectionAsType,
+} from './moduleSection.entity';
+
+export class ModuleSectionProgress {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'string',
+  })
+  userId: string;
+  @ApiProperty({
+    type: () => User,
+    required: false,
+  })
+  user?: UserAsType;
+  @ApiProperty({
+    type: 'string',
+  })
+  moduleSectionId: string;
+  @ApiProperty({
+    type: () => ModuleSection,
+    required: false,
+  })
+  moduleSection?: ModuleSectionAsType;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+  })
+  completedAt: Date | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/update-moduleSectionProgress.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-moduleSectionProgress.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class UpdateModuleSectionProgressDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsDateString()
+  completedAt?: Date | null;
+}

--- a/backend/src/generated/nestjs-dto/user.entity.ts
+++ b/backend/src/generated/nestjs-dto/user.entity.ts
@@ -46,6 +46,10 @@ import {
   ModuleContent,
   type ModuleContent as ModuleContentAsType,
 } from './moduleContent.entity';
+import {
+  ModuleSectionProgress,
+  type ModuleSectionProgress as ModuleSectionProgressAsType,
+} from './moduleSectionProgress.entity';
 
 export class User {
   @ApiProperty({
@@ -80,6 +84,8 @@ export class User {
   publishedSections?: ModuleSectionAsType[];
   @ApiHideProperty()
   publishedContents?: ModuleContentAsType[];
+  @ApiHideProperty()
+  moduleSectionProgress?: ModuleSectionProgressAsType[];
   @ApiProperty({
     type: 'string',
   })

--- a/backend/src/modules/lms/dto/create-module-section.dto.ts
+++ b/backend/src/modules/lms/dto/create-module-section.dto.ts
@@ -1,0 +1,15 @@
+import { CreateModuleSectionDto as AutoGenDto } from '@/generated/nestjs-dto/create-moduleSection.dto';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsString } from "class-validator";
+
+export class CreateModuleSectionDto extends AutoGenDto {
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  parentSectionId?: string | null;
+
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  prerequisiteSectionId?: string | null;
+}

--- a/backend/src/modules/lms/dto/detailed-module-section.dto.ts
+++ b/backend/src/modules/lms/dto/detailed-module-section.dto.ts
@@ -1,0 +1,14 @@
+import { ModuleSectionDto } from "@/generated/nestjs-dto/moduleSection.dto";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class DetailedModuleSectionDto extends ModuleSectionDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  prerequisiteSectionId?: string | null;
+  @ApiProperty({
+    type: 'string',
+  })
+  parentSectionId?: string | null;
+
+}

--- a/backend/src/modules/lms/dto/update-module-section.dto.ts
+++ b/backend/src/modules/lms/dto/update-module-section.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateModuleSectionDto } from "./create-module-section.dto";
+
+export class UpdateModuleSectionDto extends PartialType(CreateModuleSectionDto) {}

--- a/backend/src/modules/lms/lms-section.controller.ts
+++ b/backend/src/modules/lms/lms-section.controller.ts
@@ -1,7 +1,78 @@
-import { Controller } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  InternalServerErrorException,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { LmsSectionService } from '@/modules/lms/lms-section.service';
+import { Roles } from '@/common/decorators/roles.decorator';
+import { Role } from '@/common/enums/roles.enum';
+import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
+import { CreateModuleSectionDto } from './dto/create-module-section.dto';
+import { UpdateModuleSectionDto } from './dto/update-module-section.dto';
+import { DeleteQueryDto } from '@/common/dto/delete-query.dto';
 
-@Controller('modules')
+@Controller('modules/:moduleId/sections')
 export class LmsSectionController {
   constructor(private readonly lmsSectionService: LmsSectionService) {}
+
+  /**
+   * Creates a new module section
+   *
+   * @remarks
+   * Requires `ADMIN` role
+   *
+   */
+  @Post()
+  @Roles(Role.ADMIN)
+  @ApiException(() => [BadRequestException, InternalServerErrorException])
+  create(
+    @Param('moduleId', new ParseUUIDPipe()) moduleId: string,
+    @Body() dto: CreateModuleSectionDto,
+  ) {
+    return this.lmsSectionService.create(moduleId, dto);
+  }
+
+  /**
+   * Retrieves module sections of the given module id
+   */
+  @Get()
+  @Roles(Role.ADMIN, Role.MENTOR, Role.STUDENT)
+  @ApiException(() => [BadRequestException, InternalServerErrorException])
+  findAllModuleSections(@Param('moduleId', new ParseUUIDPipe()) moduleId: string) {
+    return this.lmsSectionService.findByModuleId(moduleId);
+  }
+
+  /**
+   * Updates a module section
+   * 
+   * @remarks
+   * Requires `ADMIN` role
+   */
+  @Patch(':moduleSectionId')
+  @Roles(Role.ADMIN)
+  @ApiException(() => [BadRequestException, InternalServerErrorException])
+  update(@Param('moduleSectionId', new ParseUUIDPipe()) moduleSectionId: string, dto: UpdateModuleSectionDto) {
+    return this.lmsSectionService.update(moduleSectionId, dto);
+  }
+
+  /**
+   * Deletes a module section
+   * 
+   * @remarks
+   * Requires `ADMIN` role
+   */
+  @Delete(':moduleSectionId')
+  @Roles(Role.ADMIN)
+  @ApiException(() => [BadRequestException, InternalServerErrorException])
+  remove(@Param('moduleSectionId', new ParseUUIDPipe()) moduleSectionId: string, @Query() query?: DeleteQueryDto) {
+    return this.lmsSectionService.remove(moduleSectionId, query?.directDelete);
+  }
 }

--- a/backend/src/modules/lms/lms-section.service.ts
+++ b/backend/src/modules/lms/lms-section.service.ts
@@ -1,11 +1,181 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { CustomPrismaService } from 'nestjs-prisma';
 import { ExtendedPrismaClient } from '@/lib/prisma/prisma.extension';
+import { LogParam } from '@/common/decorators/log-param.decorator';
+import { Log } from '@/common/decorators/log.decorator';
+import {
+  PrismaError,
+  PrismaErrorCode,
+} from '@/common/decorators/prisma-error.decorator';
+import { CreateModuleSectionDto } from './dto/create-module-section.dto';
+import { UpdateModuleSectionDto } from './dto/update-module-section.dto';
+import { DetailedModuleSectionDto } from './dto/detailed-module-section.dto';
 
 @Injectable()
 export class LmsSectionService {
   constructor(
     @Inject('PrismaService')
     private prisma: CustomPrismaService<ExtendedPrismaClient>,
-  ) {}
+  ) { }
+
+  /**
+   * Creates a new module section in the database.
+   *
+   * @async
+   * @param {string} moduleId - The UUID of the module to which the section belongs.
+   * @param {CreateModuleSectionDto} dto - Data Transfer Object containing the details of the module section to create.   
+   * @returns {Promise<DetailedModuleSectionDto>} - The created course section record
+   * @throws {NotFoundException} - If the specified module is not found.
+   */
+  @Log({
+    logArgsMessage: ({ moduleId }) =>
+      `Creating module section for module ${moduleId}`,
+    logSuccessMessage: (_, { moduleId }) =>
+      `Created module section for module ${moduleId}`,
+    logErrorMessage: (err, { moduleId }) =>
+      `Creating module section for module ${moduleId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RelatedRecordNotFound]: (_, { moduleId }) =>
+      new NotFoundException(`Module ${moduleId} not found`),
+  })
+  async create(
+    @LogParam('moduleId') moduleId: string,
+    dto: CreateModuleSectionDto,
+  ): Promise<DetailedModuleSectionDto> {
+    return this.prisma.client.moduleSection.create({
+      data: { moduleId, ...dto },
+    });
+  }
+
+  /**
+   * Retrieves all module sections for a given module, including nested subsections.
+   *
+   * @async
+   * @param {string} moduleId - The UUID of the module
+   * @returns {Promise<DetailedModuleSectionDto[]>} - A list of module sections with their nested subsections.
+   * @throws {NotFoundException} - If the specified module is not found.
+   */
+  @Log({
+    logArgsMessage: ({ moduleId }) =>
+      `Fetching module sections for module ${moduleId}`,
+    logSuccessMessage: (_, { moduleId }) =>
+      `Feteched module sections for module ${moduleId}`,
+    logErrorMessage: (err, { moduleId }) =>
+      `Fetching module section for module ${moduleId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, { moduleId }) =>
+      new NotFoundException(`Module ${moduleId} not found`),
+  })
+  async findByModuleId(
+    @LogParam('moduleId') moduleId: string,
+  ): Promise<DetailedModuleSectionDto[]> {
+    return this.prisma.client.moduleSection.findMany({
+      // Top level section e.g. Week 1
+      where: {
+        moduleId,
+      },
+      // Could include module contents
+      include: {
+        // Nested subsection e.g. Overview
+        subsections: {
+          include: {
+            subsections: true, // Could represent 'Exceptations', 'Expected Output', etc.,
+          },
+        },
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    });
+  }
+
+  /**
+   * Updates the details of an existing module section.
+   * 
+   * @async
+   * @param {string} moduleSectionId - The UUID of the module section to update.
+   * @param {UpdateModuleSectionDto} dto - Data Transfer Object containing the updated module section details. 
+   * @returns {Promise<DetailedModuleSectionDto>} - The updated module section
+   * @throws {NotFoundException} - If the specified module section is not found.
+   */
+  @Log({
+    logArgsMessage: ({ moduleSectionId }) =>
+      `Updating module section ${moduleSectionId}`,
+    logSuccessMessage: (moduleSection, { moduleSectionId }) =>
+      `Updated module section ${moduleSectionId} ${moduleSection.title}`,
+    logErrorMessage: (err, { moduleSectionId }) =>
+      `Updating module section ${moduleSectionId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, { moduleSectionId }) => new NotFoundException(`Module section ${moduleSectionId} not found`)
+  })
+  async update(@LogParam('moduleSectionId') moduleSectionId: string, dto: UpdateModuleSectionDto): Promise<DetailedModuleSectionDto> {
+    return this.prisma.client.moduleSection.update({
+      where: {
+        id: moduleSectionId
+      }, data: {
+        ...dto
+      }
+    })
+  }
+
+  /**
+   * Delets a module section from the database.
+   * 
+   * - If `directDelete` is false (or omitted), the module section is soft-deleted (sets `deletedAt`).
+   * - If `directDelete` is true, the module section is permanently deleted.
+   * 
+   * @async
+   * @param {string} moduleSectionId - The UUID of the module section to delete.
+   * @param {boolean} [directDelete=false] - Whether to permanently delete the module.
+   * @returns {Promise<{message: string}>} - Deletion confirmation message.
+   * @throws {NotFoundException} - If no module section is found with the given id.
+   */
+  @Log({
+    logArgsMessage: ({ moduleSectionId, directDelete }) =>
+      `Deleting module section ${moduleSectionId} hard delete=${directDelete ?? false}`,
+    logSuccessMessage: (_, { moduleSectionId, directDelete }) =>
+      `Deleted module section ${moduleSectionId} hard delete=${directDelete ?? false}`,
+    logErrorMessage: (err, { moduleSectionId }) =>
+      `Deleting module section ${moduleSectionId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, {moduleSectionId}) => new NotFoundException(`Module section ${moduleSectionId} not found`)
+  })
+  async remove(@LogParam('moduleSectionId') moduleSectionId: string, @LogParam('directDelete') directDelete?: boolean): Promise<{ message: string }> {
+    const moduleSection = await this.prisma.client.moduleSection.findUniqueOrThrow({
+      where: { id: moduleSectionId }
+    })
+
+    const now = new Date();
+
+    if (!directDelete && !moduleSection.deletedAt) {
+      await this.prisma.client.$transaction([
+        this.prisma.client.moduleSection.update({
+          where: { id: moduleSectionId },
+          data: {
+            deletedAt: now
+          }
+        }),
+        this.prisma.client.moduleContent.updateMany({
+          where: { moduleSectionId: moduleSectionId },
+          data: {
+            deletedAt: now
+          }
+        })
+      ])
+
+      return {
+        message: `Module section "${moduleSectionId}" and all associated contents were marked as deleted.`,
+      };
+
+    }
+
+    await this.prisma.client.moduleSection.delete({ where: { id: moduleSectionId } })
+    return {
+      message: `Module section "${moduleSectionId}" and all associated contents were permanently deleted.`,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
This PR introduces full CRUD support for module sections, updates related models to track user progress, and regenerates DTOs to reflect schema changes.


## Changes

### LmsSectionService and LmsSectionController
- Implemented `LmsSectionService` with full CRUD support for module sections.
- Implemented `LmsSectionController` endpoints for create, read, update, and delete operations.
- Added DTOs:
  - `CreateModuleSectionDto` with optional `parentSectionId` and `prerequisiteSectionId`
  - `UpdateModuleSectionDto` (`PartialType`)
  - `DetailedModuleSectionDto` extending generated `ModuleSectionDto`

### User, ModuleSection, and ModuleSectionProgress
- Added `ModuleSectionProgress` model to track user progress per module section.
- Updated `User` model to include `moduleSectionProgress` relation.
- Extended `ModuleSection` with prerequisite/dependent sections relations.
- Minor adjustments to existing relations for better tracking of user progress.

### Chores
- Regenerated DTOs to reflect updated models.