### PR TITLE
[CAP-179-181] Feat: (BE) add group module & fix assignment groupSnapshot

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -66,6 +66,8 @@ model User {
   postedDiscussions    DiscussionPost[]
   /// @DtoApiHidden
   moduleProgress       ContentProgress[]
+  /// @DtoApiHidden
+  groups               GroupMember[]
 
   firstName  String
   middleName String?
@@ -546,6 +548,8 @@ model Module {
   moduleContents ModuleContent[]
   /// @DtoApiHidden
   progresses     ContentProgress[]
+  /// @DtoApiHidden
+  groups         Group[]
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -722,6 +726,11 @@ model AssignmentSubmission {
 
   /// @DtoApiHidden
   student User @relation(fields: [studentId], references: [id])
+
+  // Group submissions
+  groupId       String? @db.Uuid
+  group         Group?  @relation(fields: [groupId], references: [id])
+  groupSnapshot Json?
 
   /// Text submission
   content       Json?
@@ -1024,6 +1033,40 @@ model AssignmentGradeRecord {
   @@index([studentId, finalScore])
   @@index([gradedAt])
   @@index([finalScore, gradingId])
+}
+
+model Group {
+  id String @id @default(uuid()) @db.Uuid
+
+  moduleId String @db.Uuid
+  module   Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+
+  groupNumber Int
+  groupName   String?
+  /// @DtoApiHidden
+  members     GroupMember[]
+  /// @DtoApiHidden
+  submissions AssignmentSubmission[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([moduleId, groupNumber])
+}
+
+model GroupMember {
+  id String @id @default(uuid()) @db.Uuid
+
+  groupId String @db.Uuid
+  group   Group  @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  studentId String @db.Uuid
+  user      User   @relation(fields: [studentId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([groupId, studentId])
 }
 
 model Notification {

--- a/backend/src/generated/nestjs-dto/assignmentSubmission.dto.ts
+++ b/backend/src/generated/nestjs-dto/assignmentSubmission.dto.ts
@@ -10,6 +10,11 @@ export class AssignmentSubmissionDto {
     type: () => Object,
     nullable: true,
   })
+  groupSnapshot: Prisma.JsonValue | null;
+  @ApiProperty({
+    type: () => Object,
+    nullable: true,
+  })
   content: Prisma.JsonValue | null;
   @ApiProperty({
     type: 'string',

--- a/backend/src/generated/nestjs-dto/assignmentSubmission.entity.ts
+++ b/backend/src/generated/nestjs-dto/assignmentSubmission.entity.ts
@@ -5,6 +5,7 @@ import {
   type Assignment as AssignmentAsType,
 } from './assignment.entity';
 import { User, type User as UserAsType } from './user.entity';
+import { Group, type Group as GroupAsType } from './group.entity';
 import {
   AssignmentAttachment,
   type AssignmentAttachment as AssignmentAttachmentAsType,
@@ -30,6 +31,22 @@ export class AssignmentSubmission {
   studentId: string;
   @ApiHideProperty()
   student?: UserAsType;
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+  })
+  groupId: string | null;
+  @ApiProperty({
+    type: () => Group,
+    required: false,
+    nullable: true,
+  })
+  group?: GroupAsType | null;
+  @ApiProperty({
+    type: () => Object,
+    nullable: true,
+  })
+  groupSnapshot: Prisma.JsonValue | null;
   @ApiProperty({
     type: () => Object,
     nullable: true,

--- a/backend/src/generated/nestjs-dto/connect-group.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-group.dto.ts
@@ -1,0 +1,44 @@
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GroupModuleIdGroupNumberUniqueInputDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  moduleId: string;
+  @ApiProperty({
+    type: 'integer',
+    format: 'int32',
+  })
+  @IsNotEmpty()
+  @IsInt()
+  groupNumber: number;
+}
+
+@ApiExtraModels(GroupModuleIdGroupNumberUniqueInputDto)
+export class ConnectGroupDto {
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  id?: string;
+  @ApiProperty({
+    type: GroupModuleIdGroupNumberUniqueInputDto,
+    required: false,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GroupModuleIdGroupNumberUniqueInputDto)
+  moduleId_groupNumber?: GroupModuleIdGroupNumberUniqueInputDto;
+}

--- a/backend/src/generated/nestjs-dto/connect-groupMember.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-groupMember.dto.ts
@@ -1,0 +1,42 @@
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GroupMemberGroupIdStudentIdUniqueInputDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  groupId: string;
+  @ApiProperty({
+    type: 'string',
+  })
+  @IsNotEmpty()
+  @IsString()
+  studentId: string;
+}
+
+@ApiExtraModels(GroupMemberGroupIdStudentIdUniqueInputDto)
+export class ConnectGroupMemberDto {
+  @ApiProperty({
+    type: 'string',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  id?: string;
+  @ApiProperty({
+    type: GroupMemberGroupIdStudentIdUniqueInputDto,
+    required: false,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GroupMemberGroupIdStudentIdUniqueInputDto)
+  groupId_studentId?: GroupMemberGroupIdStudentIdUniqueInputDto;
+}

--- a/backend/src/generated/nestjs-dto/create-assignmentSubmission.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-assignmentSubmission.dto.ts
@@ -9,6 +9,13 @@ export class CreateAssignmentSubmissionDto {
     nullable: true,
   })
   @IsOptional()
+  groupSnapshot?: Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput;
+  @ApiProperty({
+    type: () => Object,
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
   content?: Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput;
   @ApiProperty({
     type: 'string',

--- a/backend/src/generated/nestjs-dto/create-group.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-group.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateGroupDto {
+  @ApiProperty({
+    type: 'integer',
+    format: 'int32',
+  })
+  @IsNotEmpty()
+  @IsInt()
+  groupNumber: number;
+  @ApiProperty({
+    type: 'string',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  groupName?: string | null;
+}

--- a/backend/src/generated/nestjs-dto/create-groupMember.dto.ts
+++ b/backend/src/generated/nestjs-dto/create-groupMember.dto.ts
@@ -1,0 +1,1 @@
+export class CreateGroupMemberDto {}

--- a/backend/src/generated/nestjs-dto/group.dto.ts
+++ b/backend/src/generated/nestjs-dto/group.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GroupDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'integer',
+    format: 'int32',
+  })
+  groupNumber: number;
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+  })
+  groupName: string | null;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/group.entity.ts
+++ b/backend/src/generated/nestjs-dto/group.entity.ts
@@ -1,0 +1,50 @@
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { Module, type Module as ModuleAsType } from './module.entity';
+import {
+  GroupMember,
+  type GroupMember as GroupMemberAsType,
+} from './groupMember.entity';
+import {
+  AssignmentSubmission,
+  type AssignmentSubmission as AssignmentSubmissionAsType,
+} from './assignmentSubmission.entity';
+
+export class Group {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'string',
+  })
+  moduleId: string;
+  @ApiProperty({
+    type: () => Module,
+    required: false,
+  })
+  module?: ModuleAsType;
+  @ApiProperty({
+    type: 'integer',
+    format: 'int32',
+  })
+  groupNumber: number;
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+  })
+  groupName: string | null;
+  @ApiHideProperty()
+  members?: GroupMemberAsType[];
+  @ApiHideProperty()
+  submissions?: AssignmentSubmissionAsType[];
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/groupMember.dto.ts
+++ b/backend/src/generated/nestjs-dto/groupMember.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GroupMemberDto {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/groupMember.entity.ts
+++ b/backend/src/generated/nestjs-dto/groupMember.entity.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Group, type Group as GroupAsType } from './group.entity';
+import { User, type User as UserAsType } from './user.entity';
+
+export class GroupMember {
+  @ApiProperty({
+    type: 'string',
+  })
+  id: string;
+  @ApiProperty({
+    type: 'string',
+  })
+  groupId: string;
+  @ApiProperty({
+    type: () => Group,
+    required: false,
+  })
+  group?: GroupAsType;
+  @ApiProperty({
+    type: 'string',
+  })
+  studentId: string;
+  @ApiProperty({
+    type: () => User,
+    required: false,
+  })
+  user?: UserAsType;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  createdAt: Date;
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+  })
+  updatedAt: Date;
+}

--- a/backend/src/generated/nestjs-dto/module.entity.ts
+++ b/backend/src/generated/nestjs-dto/module.entity.ts
@@ -16,6 +16,7 @@ import {
   ContentProgress,
   type ContentProgress as ContentProgressAsType,
 } from './contentProgress.entity';
+import { Group, type Group as GroupAsType } from './group.entity';
 
 export class Module {
   @ApiProperty({
@@ -57,6 +58,8 @@ export class Module {
   moduleContents?: ModuleContentAsType[];
   @ApiHideProperty()
   progresses?: ContentProgressAsType[];
+  @ApiHideProperty()
+  groups?: GroupAsType[];
   @ApiProperty({
     type: 'string',
     format: 'date-time',

--- a/backend/src/generated/nestjs-dto/update-assignmentSubmission.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-assignmentSubmission.dto.ts
@@ -9,6 +9,13 @@ export class UpdateAssignmentSubmissionDto {
     nullable: true,
   })
   @IsOptional()
+  groupSnapshot?: Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput;
+  @ApiProperty({
+    type: () => Object,
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
   content?: Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput;
   @ApiProperty({
     type: 'string',

--- a/backend/src/generated/nestjs-dto/update-group.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-group.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateGroupDto {
+  @ApiProperty({
+    type: 'integer',
+    format: 'int32',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  groupNumber?: number;
+  @ApiProperty({
+    type: 'string',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  groupName?: string | null;
+}

--- a/backend/src/generated/nestjs-dto/update-groupMember.dto.ts
+++ b/backend/src/generated/nestjs-dto/update-groupMember.dto.ts
@@ -1,0 +1,1 @@
+export class UpdateGroupMemberDto {}

--- a/backend/src/generated/nestjs-dto/user.entity.ts
+++ b/backend/src/generated/nestjs-dto/user.entity.ts
@@ -49,6 +49,10 @@ import {
   ContentProgress,
   type ContentProgress as ContentProgressAsType,
 } from './contentProgress.entity';
+import {
+  GroupMember,
+  type GroupMember as GroupMemberAsType,
+} from './groupMember.entity';
 
 export class User {
   @ApiProperty({
@@ -81,6 +85,8 @@ export class User {
   postedDiscussions?: DiscussionPostAsType[];
   @ApiHideProperty()
   moduleProgress?: ContentProgressAsType[];
+  @ApiHideProperty()
+  groups?: GroupMemberAsType[];
   @ApiProperty({
     type: 'string',
   })

--- a/backend/src/modules/lms/content/assignment/assignment-submission.service.ts
+++ b/backend/src/modules/lms/content/assignment/assignment-submission.service.ts
@@ -60,6 +60,7 @@ export class AssignmentSubmissionService {
     return {
       ...submission,
       content: submission.content as Prisma.JsonValue,
+      groupSnapshot: submission.groupSnapshot as Prisma.JsonValue,
     };
   }
 
@@ -91,6 +92,7 @@ export class AssignmentSubmissionService {
     return {
       ...submission,
       content: submission.content as Prisma.JsonValue,
+      groupSnapshot: submission.groupSnapshot as Prisma.JsonValue,
     };
   }
 
@@ -116,6 +118,7 @@ export class AssignmentSubmissionService {
     return {
       ...result,
       content: result.content as Prisma.JsonValue,
+      groupSnapshot: result.groupSnapshot as Prisma.JsonValue,
     };
   }
 
@@ -141,6 +144,7 @@ export class AssignmentSubmissionService {
     return results.map((r) => ({
       ...r,
       content: r.content as Prisma.JsonValue,
+      groupSnapshot: r.groupSnapshot as Prisma.JsonValue,
     }));
   }
 
@@ -165,6 +169,7 @@ export class AssignmentSubmissionService {
     return results.map((r) => ({
       ...r,
       content: r.content as Prisma.JsonValue,
+      groupSnapshot: r.groupSnapshot as Prisma.JsonValue,
     }));
   }
 
@@ -189,6 +194,7 @@ export class AssignmentSubmissionService {
     return results.map((r) => ({
       ...r,
       content: r.content as Prisma.JsonValue,
+      groupSnapshot: r.groupSnapshot as Prisma.JsonValue,
     }));
   }
 

--- a/backend/src/modules/lms/content/assignment/assignment.service.ts
+++ b/backend/src/modules/lms/content/assignment/assignment.service.ts
@@ -157,6 +157,7 @@ export class AssignmentService {
       submissions: assignment.submissions.map((submission) => ({
         ...submission,
         content: submission.content as Prisma.JsonValue,
+        groupSnapshot: submission.groupSnapshot as Prisma.JsonValue,
       })),
     };
   }

--- a/backend/src/modules/lms/group/dto/create-group.dto.ts
+++ b/backend/src/modules/lms/group/dto/create-group.dto.ts
@@ -1,0 +1,15 @@
+import { CreateGroupDto } from '@/generated/nestjs-dto/create-group.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class CreateDetailedGroupDto extends CreateGroupDto {
+  @ApiProperty({
+    type: 'array',
+    items: { type: 'string', format: 'uuid' },
+    description: 'List of student IDs to assign as member',
+  })
+  @IsArray()
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  members: string[];
+}

--- a/backend/src/modules/lms/group/dto/detailed-group.dto.ts
+++ b/backend/src/modules/lms/group/dto/detailed-group.dto.ts
@@ -1,0 +1,27 @@
+import { GroupDto } from '@/generated/nestjs-dto/group.dto';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+
+export class StudentInfoDto {
+  @ApiProperty({ type: 'string' })
+  firstName: string;
+
+  @ApiProperty({ type: 'string' })
+  lastName: string;
+}
+
+export class GroupMemberDto {
+  @ApiProperty({ type: 'string', format: 'uuid' })
+  studentId: string;
+
+  @ApiProperty({ type: () => StudentInfoDto })
+  user: StudentInfoDto;
+}
+
+export class DetailedGroupDto extends PickType(GroupDto, [
+  'id',
+  'groupNumber',
+  'groupName',
+]) {
+  @ApiProperty({ type: () => [GroupMemberDto] })
+  members: GroupMemberDto[];
+}

--- a/backend/src/modules/lms/group/dto/update-group.dto.ts
+++ b/backend/src/modules/lms/group/dto/update-group.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateDetailedGroupDto } from './create-group.dto';
+
+export class UpdateGroupDto extends PartialType(CreateDetailedGroupDto) {}

--- a/backend/src/modules/lms/group/group.controller.ts
+++ b/backend/src/modules/lms/group/group.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { GroupService } from './group.service';
+import { CreateDetailedGroupDto } from './dto/create-group.dto';
+import { Roles } from '@/common/decorators/roles.decorator';
+import { Role } from '@/common/enums/roles.enum';
+import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
+import { UpdateGroupDto } from './dto/update-group.dto';
+
+@Controller('modules/:moduleId/groups')
+export class GroupController {
+  constructor(private readonly groupService: GroupService) {}
+
+  /**
+   * Creates a new group
+   *
+   * @remarks
+   * Requires `ADMIN` or `MENTOR` role
+   *
+   */
+  @Post()
+  @Roles(Role.ADMIN, Role.MENTOR)
+  @ApiException(() => [NotFoundException, InternalServerErrorException])
+  create(
+    @Param('moduleId', new ParseUUIDPipe()) moduleId: string,
+    @Body() createGroupDto: CreateDetailedGroupDto,
+  ) {
+    return this.groupService.create(moduleId, createGroupDto);
+  }
+
+  /**
+   * Retrieves groups of the given module id
+   *
+   * @remarks
+   * Requires `ADMIN` or `MENTOR` role
+   *
+   */
+  @Get()
+  @Roles(Role.ADMIN, Role.MENTOR)
+  @ApiException(() => [NotFoundException, InternalServerErrorException])
+  findAll(@Param('moduleId', new ParseUUIDPipe()) moduleId: string) {
+    return this.groupService.findAll(moduleId);
+  }
+
+  /**
+   * Updates a group
+   *
+   * @remarks
+   * Requires `ADMIN` or `MENTOR` role
+   *
+   */
+  @Patch(':id')
+  @Roles(Role.ADMIN, Role.MENTOR)
+  @ApiException(() => [NotFoundException, InternalServerErrorException])
+  update(@Param('id') id: string, @Body() updateGroupDto: UpdateGroupDto) {
+    return this.groupService.update(id, updateGroupDto);
+  }
+
+  /**
+   * Deletes a group
+   *
+   * @remarks
+   * Requires `ADMIN` or `MENTOR` role
+   *
+   */
+  @Delete(':id')
+  @Roles(Role.ADMIN, Role.MENTOR)
+  @ApiException(() => [NotFoundException, InternalServerErrorException])
+  remove(@Param('id') id: string) {
+    return this.groupService.remove(id);
+  }
+}

--- a/backend/src/modules/lms/group/group.module.ts
+++ b/backend/src/modules/lms/group/group.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GroupService } from './group.service';
+import { GroupController } from './group.controller';
+
+@Module({
+  controllers: [GroupController],
+  providers: [GroupService],
+})
+export class GroupModule {}

--- a/backend/src/modules/lms/group/group.service.ts
+++ b/backend/src/modules/lms/group/group.service.ts
@@ -1,0 +1,191 @@
+import { ExtendedPrismaClient } from '@/lib/prisma/prisma.extension';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CustomPrismaService } from 'nestjs-prisma';
+import { CreateDetailedGroupDto } from './dto/create-group.dto';
+import { DetailedGroupDto } from './dto/detailed-group.dto';
+import { Log } from '@/common/decorators/log.decorator';
+import {
+  PrismaError,
+  PrismaErrorCode,
+} from '@/common/decorators/prisma-error.decorator';
+import { LogParam } from '@/common/decorators/log-param.decorator';
+import { UpdateGroupDto } from './dto/update-group.dto';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class GroupService {
+  constructor(
+    @Inject('PrismaService')
+    private prisma: CustomPrismaService<ExtendedPrismaClient>,
+  ) {}
+
+  /**
+   * Creates a new group in the database.
+   *
+   * @async
+   * @param {string} moduleId - The UUID of the module to which the group belongs.
+   * @param {CreateDetailedGroupDto} dto - Data Transfer Object containing the details of the group to create.
+   * @returns {Promise<DetailedGroupDto>} - The created group record.
+   * @throws {NotFoundException} - If the specified moduleId or userId/s is not found.
+   */
+  @Log({
+    logArgsMessage: ({ moduleId }) => `Creating group for module ${moduleId}`,
+    logSuccessMessage: (_, { moduleId }) =>
+      `Created group for module ${moduleId}`,
+    logErrorMessage: (err, { moduleId }) =>
+      `Creating group for module ${moduleId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RelatedRecordNotFound]: (_, { moduleId }) =>
+      new NotFoundException(`Module ${moduleId} not found`),
+  })
+  async create(
+    @LogParam('moduleId') moduleId: string,
+    dto: CreateDetailedGroupDto,
+  ): Promise<DetailedGroupDto> {
+    return await this.prisma.client.group.create({
+      data: {
+        moduleId,
+        ...dto,
+        members: {
+          create: dto.members.map((studentId) => ({ studentId })),
+        },
+      },
+      include: {
+        members: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Retrieves all groups for a given module.
+   *
+   * @async
+   * @param {string} moduleId - The UUID of the module
+   * @returns {Promise<DetailedGroupDto[]>} - A list of groups.
+   * @throws {NotFoundException} - If the specified module is not found.
+   */
+  @Log({
+    logArgsMessage: ({ moduleId }) => `Fetching groups for module ${moduleId}`,
+    logSuccessMessage: (_, { moduleId }) =>
+      `Fetched groups for module ${moduleId}`,
+    logErrorMessage: (err, { moduleId }) =>
+      `Fetching groups for module ${moduleId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, { moduleId }) =>
+      new NotFoundException(`Module ${moduleId} not found`),
+  })
+  async findAll(
+    @LogParam('moduleId') moduleId: string,
+  ): Promise<DetailedGroupDto[]> {
+    return this.prisma.client.group.findMany({
+      where: { moduleId },
+      select: {
+        id: true,
+        groupNumber: true,
+        groupName: true,
+        members: {
+          select: {
+            studentId: true,
+            user: {
+              select: {
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Updates the details of an existing group.
+   *
+   * @async
+   * @param {string} groupId - The UUID of the group to update.
+   * @param {CreateDetailedGroupDto} dto - Data Transfer Object containing the group details.
+   * @returns {Promise<DetailedGroupDto>} - The updated group.
+   * @throws {NotFoundException} - If the specified groupId or userId/s is not found.
+   */
+  @Log({
+    logArgsMessage: ({ groupId }) => `Updating group ${groupId}`,
+    logSuccessMessage: (_, { groupId }) => `Updated group ${groupId}`,
+    logErrorMessage: (err, { groupId }) =>
+      `Updating group ${groupId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, { groupId }) =>
+      new NotFoundException(`Group ${groupId} not found`),
+  })
+  async update(
+    @LogParam('groupId') groupId: string,
+    dto: UpdateGroupDto,
+  ): Promise<DetailedGroupDto> {
+    const { members, ...details } = dto;
+
+    const data: Prisma.GroupUpdateInput = {
+      ...details,
+    };
+
+    if (members?.length) {
+      data.members = {
+        set: [],
+        create: members.map((studentId) => ({ studentId })),
+      };
+    }
+
+    return this.prisma.client.group.update({
+      where: { id: groupId },
+      data,
+      include: {
+        members: {
+          select: {
+            studentId: true,
+            user: { select: { firstName: true, lastName: true } },
+          },
+        },
+      },
+    });
+  }
+
+  /**
+   * Deletes a group from the database.
+   *
+   * @async
+   * @param {string} groupId - The UUID of the group to delete.
+   * @returns {Promise<{message: string}>} - Deletion confirmation message.
+   * @throws {NotFoundException} - If no group is found with the given id.
+   */
+  @Log({
+    logArgsMessage: ({ groupId }) => `Deleting group ${groupId}`,
+    logSuccessMessage: (_, { groupId }) => `Deleted group ${groupId}`,
+    logErrorMessage: (err, { groupId }) =>
+      `Deleting group ${groupId} | Error: ${err.message}`,
+  })
+  @PrismaError({
+    [PrismaErrorCode.RecordNotFound]: (_, { groupId }) =>
+      new NotFoundException(`Group ${groupId} not found`),
+  })
+  async remove(
+    @LogParam('groupId') groupId: string,
+  ): Promise<{ message: string }> {
+    await this.prisma.client.group.delete({
+      where: { id: groupId },
+    });
+    return {
+      message: 'Group permanently deleted',
+    };
+  }
+}

--- a/backend/src/modules/lms/lms.module.ts
+++ b/backend/src/modules/lms/lms.module.ts
@@ -15,6 +15,7 @@ import { FileService } from '@/modules/lms/content/file/file.service';
 import { LessonService } from '@/modules/lms/content/lesson/lessson.service';
 import { UrlService } from '@/modules/lms/content/url/url.service';
 import { VideoService } from '@/modules/lms/content/video/video.service';
+import { GroupModule } from './group/group.module';
 
 @Module({
   controllers: [LmsController, LmsSectionController, LmsContentController],
@@ -48,5 +49,6 @@ import { VideoService } from '@/modules/lms/content/video/video.service';
     UrlService,
     VideoService,
   ],
+  imports: [GroupModule],
 })
 export class LmsModule {}


### PR DESCRIPTION
# This PR introduces the **Group** feature along with schema changes, service, controller, and DTOs, and also includes a fix for handling `groupSnapshot` in assignment submissions.

## What's New
- **Schema**
  - Added `Group` and `GroupMember` models
  - Added back relations:
    - `groups` to `User` and `Module`
    - `groupId`, `group`, and `groupSnapshot` to `AssignmentSubmission`

- **Group Module**
  - Implemented `GroupService` with CRUD operations
  - Implemented `GroupController` with REST endpoints
  - Added DTOs:
    - `CreateDetailedGroupDto` (extend generated DTO + members)
    - `DetailedGroupDto` (group details + member info)
    - `UpdateGroupDto` (partial update support)

- **Fixes**
  - Updated `AssignmentService` and `AssignmentSubmissionService`:
    - Ensured `groupSnapshot` is returned as `Prisma.JsonValue`
    - Prevents type mismatch (`unknown` → `JsonValue`)
    - Supports group submissions with proper JSON serialization