### PR TITLE
[CAP-204] FIX: (FE) Only Render Term Combobox for Admin

### DIFF
--- a/frontend/src/features/courses/dashboard/course-dashboard-header.tsx
+++ b/frontend/src/features/courses/dashboard/course-dashboard-header.tsx
@@ -1,4 +1,6 @@
 import { MultiFilter, type FilterType } from '@/components/multi-filter.tsx'
+import RoleComponentManager from '@/components/role-component-manager'
+import { useAuth } from '@/features/auth/auth.hook'
 import {
   Box,
   Button,
@@ -26,6 +28,7 @@ type DashboardHeaderProps = {
 }
 
 function CourseDashboardHeader({ view, onViewChange }: DashboardHeaderProps) {
+  const { authUser } = useAuth('protected')
   return (
     <Stack gap="md">
       <Box>
@@ -55,7 +58,12 @@ function CourseDashboardHeader({ view, onViewChange }: DashboardHeaderProps) {
           onRemoveFilter={handleRemoveFilter}
           onFilterChange={handleFilterChange}
         /> */}
-        <AsyncTermCombobox />
+        <RoleComponentManager
+          currentRole={authUser.role}
+          roleRender={{
+            admin: <AsyncTermCombobox />,
+          }}
+        />
         <ViewSelectorButton
           view={view}
           onGridClick={() => onViewChange('grid')}


### PR DESCRIPTION
This pull request updates the `CourseDashboardHeader` component to conditionally render the `AsyncTermCombobox` based on the user's role. Now, only users with the `admin` role will see the term combobox. This is achieved by introducing the `RoleComponentManager` component and retrieving the current user's role via the authentication hook.

**Role-based UI rendering:**

* Added import and usage of `RoleComponentManager` to conditionally render components based on user role in `course-dashboard-header.tsx`. [[1]](diffhunk://#diff-74dceb61bca155a96e89af73d7dfc24b370a3e48ab935d1e35b09eb70f7b7b68R2-R3) [[2]](diffhunk://#diff-74dceb61bca155a96e89af73d7dfc24b370a3e48ab935d1e35b09eb70f7b7b68L58-R66)
* Integrated the `useAuth` hook to access the authenticated user's role for conditional rendering.