### PR TITLE
[CAP-209] CONF: (FE) Change the baseUrl based on .env

### DIFF
--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -3,8 +3,8 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 
 import TanStackQueryLayout from '@/integrations/tanstack-query/layout.tsx'
 
-import type { QueryClient } from '@tanstack/react-query'
 import { client } from '@/integrations/api/client/client.gen'
+import type { QueryClient } from '@tanstack/react-query'
 
 interface RouterContext {
   queryClient: QueryClient
@@ -20,7 +20,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   ),
   beforeLoad: () => {
     client.setConfig({
-      baseUrl: 'http://localhost:3001',
+      baseUrl: import.meta.env.VITE_API_URL,
     })
   },
 })


### PR DESCRIPTION
This pull request updates the API client configuration to use an environment variable for the base URL, improving flexibility for different deployment environments. It also makes a minor import order adjustment.

API configuration improvements:
* Updated the `client.setConfig` call in `__root.tsx` to use the `VITE_API_URL` environment variable instead of a hardcoded localhost URL, allowing the API base URL to be configured per environment.

Code style/maintenance:
* Reordered the import of `QueryClient` in `__root.tsx` for consistency and clarity.