### PR TITLE
[CAP-221] Fix: (BE) Schema replace unique with index for moduleSection.order

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -228,7 +228,7 @@ model Course {
   coreqFor Course[] @relation("CourseCoreq")
 
   /// @DtoApiHidden
-  modules         Module[]
+  modules Module[]
 
   curriculumCourses CurriculumCourse[]
 
@@ -346,7 +346,7 @@ model CourseOffering {
   /// @DtoApiHidden
   courseSections    CourseSection[] // Each offering can have multiple sections
   /// @DtoApiHidden
-  modules Module[]
+  modules           Module[]
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -541,14 +541,14 @@ enum PricingType {
 }
 
 model Pricing {
-  id            String           @id @default(uuid()) @db.Uuid
+  id          String         @id @default(uuid()) @db.Uuid
   /// @DtoApiHidden
   priceGroups PricingGroup[]
 
   type    PricingType
-  name String @unique
-  amount       Decimal     @db.Decimal(10, 2)
-  enabled Boolean @default(true)
+  name    String      @unique
+  amount  Decimal     @db.Decimal(10, 2)
+  enabled Boolean     @default(true)
 
   /// @DtoReadOnly
   createdAt DateTime  @default(now())
@@ -559,12 +559,12 @@ model Pricing {
 }
 
 model PricingGroup {
-  id            String           @id @default(uuid()) @db.Uuid
+  id     String    @id @default(uuid()) @db.Uuid
   /// @DtoApiHidden
   prices Pricing[]
 
-  name String
-  amount       Decimal     @db.Decimal(10, 2)
+  name    String
+  amount  Decimal @db.Decimal(10, 2)
   enabled Boolean @default(true)
 
   /// @DtoReadOnly
@@ -574,7 +574,6 @@ model PricingGroup {
   /// @DtoReadOnly
   deletedAt DateTime?
 }
-
 
 model Module {
   id    String @id @default(uuid()) @db.Uuid
@@ -586,7 +585,7 @@ model Module {
 
   /// @DtoApiHidden
   courseOffering   CourseOffering? @relation(fields: [courseOfferingId], references: [id])
-  courseOfferingId String? @db.Uuid
+  courseOfferingId String?         @db.Uuid
 
   /// @DtoApiHidden
   sectionModules SectionModule[]
@@ -599,8 +598,8 @@ model Module {
   /// @DtoApiHidden
   groups         Group[]
 
-  publishedAt DateTime?
-  toPublishAt DateTime?
+  publishedAt   DateTime?
+  toPublishAt   DateTime?
   unpublishedAt DateTime?
 
   /// @DtoReadOnly
@@ -612,16 +611,16 @@ model Module {
 }
 
 model SectionModule {
-  id             String       @id @default(uuid()) @db.Uuid
-  courseSection  CourseSection @relation(fields: [courseSectionId], references: [id], onDelete: Cascade)
-  courseSectionId String      @db.Uuid
+  id              String        @id @default(uuid()) @db.Uuid
+  courseSection   CourseSection @relation(fields: [courseSectionId], references: [id], onDelete: Cascade)
+  courseSectionId String        @db.Uuid
 
-  module         Module        @relation(fields: [moduleId], references: [id], onDelete: Cascade)
-  moduleId       String        @db.Uuid
+  module   Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  moduleId String @db.Uuid
 
-  order          Int           @default(0)
-  publishedAt    DateTime?
-  toPublishAt    DateTime?
+  order       Int       @default(0)
+  publishedAt DateTime?
+  toPublishAt DateTime?
 
   classMeetings Json?
 
@@ -645,11 +644,11 @@ model ModuleSection {
   subsections     ModuleSection[] @relation("ModuleSubsection")
 
   /// @DtoApiHidden
-  prerequisiteSection   ModuleSection?  @relation("ModulePrerequisite", fields: [prerequisiteSectionId], references: [id])
-  prerequisiteSectionId String?         @db.Uuid
+  prerequisiteSection   ModuleSection? @relation("ModulePrerequisite", fields: [prerequisiteSectionId], references: [id])
+  prerequisiteSectionId String?        @db.Uuid
 
   /// @DtoApiHidden
-  dependentSections     ModuleSection[] @relation("ModulePrerequisite")
+  dependentSections ModuleSection[] @relation("ModulePrerequisite")
 
   /// @DtoApiHidden
   moduleContents ModuleContent[]
@@ -657,8 +656,8 @@ model ModuleSection {
   title String @db.VarChar(255)
   order Int    @default(0)
 
-  publishedAt DateTime?
-  toPublishAt DateTime?
+  publishedAt   DateTime?
+  toPublishAt   DateTime?
   unpublishedAt DateTime?
 
   /// @DtoReadOnly
@@ -668,7 +667,7 @@ model ModuleSection {
   /// @DtoReadOnly
   deletedAt DateTime?
 
-  @@unique([moduleId, order]) // ensure unique order within module
+  @@index([moduleId, order])
   @@index([moduleId])
   @@index([parentSectionId])
   @@index([order])

--- a/backend/src/generated/nestjs-dto/connect-moduleSection.dto.ts
+++ b/backend/src/generated/nestjs-dto/connect-moduleSection.dto.ts
@@ -1,45 +1,11 @@
-import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
-import {
-  IsInt,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
-import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
 
-export class ModuleSectionModuleIdOrderUniqueInputDto {
-  @ApiProperty({
-    type: 'string',
-  })
-  @IsNotEmpty()
-  @IsString()
-  moduleId: string;
-  @ApiProperty({
-    type: 'integer',
-    format: 'int32',
-    default: 0,
-  })
-  @IsNotEmpty()
-  @IsInt()
-  order: number;
-}
-
-@ApiExtraModels(ModuleSectionModuleIdOrderUniqueInputDto)
 export class ConnectModuleSectionDto {
   @ApiProperty({
     type: 'string',
-    required: false,
   })
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
-  id?: string;
-  @ApiProperty({
-    type: ModuleSectionModuleIdOrderUniqueInputDto,
-    required: false,
-  })
-  @IsOptional()
-  @ValidateNested()
-  @Type(() => ModuleSectionModuleIdOrderUniqueInputDto)
-  moduleId_order?: ModuleSectionModuleIdOrderUniqueInputDto;
+  id: string;
 }


### PR DESCRIPTION
## Summary

- Dropped @@unique([moduleId, order]) which blocked drag-and-drop reordering
- Added @@index([moduleId, order]) for efficient sorting without enforcing uniqueness
- Keeps auto-increment behavior on create while allowing duplicate order values