### PR TITLE
[CAP-232] HOTFIX: (FE) Updating Module Content Causes an Error

### DIFF
--- a/frontend/src/features/courses/cms/cms.tsx
+++ b/frontend/src/features/courses/cms/cms.tsx
@@ -225,7 +225,6 @@ function CMSWrapper({ courseCode }: CMSProps) {
       },
       body: {
         contentType: data.contentType,
-        ...(existingContent ?? {}),
         content: editorState.content.document,
       },
     })


### PR DESCRIPTION
This pull request makes a minor adjustment to the `CMSWrapper` component, specifically in the request body when updating course content. The change removes the spreading of `existingContent` into the body, ensuring only the new content and content type are sent.