### PR TITLE
v0.7.4 feat: add Dokploy compose file for backend deployment

### DIFF
--- a/backend/compose.dokploy.yml
+++ b/backend/compose.dokploy.yml
@@ -1,0 +1,8 @@
+services:
+  nestjs:
+    image: ghcr.io/ykzsolutions/mmdc-student-portal
+    container_name: mmdc-student-portal
+    env_file:
+      - .env
+    expose:
+      - "3001"


### PR DESCRIPTION
## Summary

Create \ackend/compose.dokploy.yml\ for Dokploy deployment, matching Firestore-ERD-Plus compose conventions.

## Changes

- \ackend/compose.dokploy.yml\ — single NestJS service on port 3001, image from GHCR, \.env\ file reference

## Related

Closes PROJ-106